### PR TITLE
docs: add content to the overview pages

### DIFF
--- a/docs/build-apps/overview.md
+++ b/docs/build-apps/overview.md
@@ -17,4 +17,4 @@ Three main integrations are available:
 
 All three of these integrations can be used together to create powerful new user experiences that rival or exceed those of traditional apps—all while protecting your users' digital rights.
 
-While integration is possible for any type of app, most of the resources available here are for web developers experienced with JavaScript.
+While integration is possible for any type of app, the resources available here are for web developers experienced with JavaScript.

--- a/docs/example-apps.md
+++ b/docs/example-apps.md
@@ -3,4 +3,11 @@ id: example-apps
 title: Example apps
 ---
 
-The following are example apps provided to help you get started building on Stacks.
+The example apps provided in this section demonstrate key features of the Stacks blockchain, including connecting to the wallet, reading on-chain values, creating transactions, and interacting with the web wallet.
+
+You can use the example apps provided here as a basis for your own Stacks app, or just as a reference for how Hirodevelopers implement specific features.
+
+- [To-dos](/docs/example-apps/to-dos): A to-do list app that demonstrates authentication with the web wallet and storing data off-chain with Gaia.
+- [Public registry](/docs/example-apps/public-registry): A extension of the to-do list that makes your list public through a Clarity smart contract.
+- [Heystack](/docs/example-apps/heystack): A public chat app featuring a comprehensive demonstraction of the web wallet, Clarity smart contracts, and the Stacks API.
+- [Angular app](/docs/example-apps/angular): An exploration of the [connect](https://github.com/blockstack/connect#readme) library from Stacks.js using the Angular framework (rather than React)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,4 +3,8 @@ id: intro
 title: Introduction
 ---
 
-Welcome to Hiro developer documentation.
+Hiro is a developer tools company that supports developers on the Stacks blockchain. Apps built on Stacks typically consist of a Clarity smart contract for handling on chain data and a JavaScript frontend on the web. Trustless data storage is also available through Gaia, which is useful for storing large amounts of app or user data off-chain.
+
+The developer documentation on this site provides information about how to use Hiro products to develop applications on the Stacks blockchain. The examples and tutorials available cover all phases of app development from smart contract to frontend. Hiro's suite of developer tools allow you to rapidly iterate on an app locally, develop comprehensive unit tests, and deploy your app to the live Stacks chain.
+
+If you are interested in general information about Stacks, including information on the STX token, mining, and learning the Clarity smart contract language, see the [official Stacks documentation](https://docs.stacks.co/).

--- a/docs/references.md
+++ b/docs/references.md
@@ -3,4 +3,23 @@ id: references
 title: Resources for Stacks developers
 ---
 
-The following references are available.
+The resources in this section are provided for reference toward developer resources in the Stacks ecosystem. From Clarity language resources to Stacks.js documentation, this section contains information for the complete development of a Stacks app.
+
+## Interacting with the blockchain
+
+The [Stacks CLI](/docs/references/stacks-cli) provides an easy way for you to interact with the Stacks live blockchain (testnet or mainnet). The CLI can be used to test transactions, perform stacking, or deploy contracts. Since the Stacks CLI operates on unencrypted private keys, it is recommended that you use the CLI as a development tool only, and not against accounts with significant amounts of mainnet STX tokens.
+
+## Contract development
+
+Smart contracts on Stacks are developed in Clarity, a LISP-based, non-Turing complete, interpreted, functional language developed specifically for use on blockchains. Hiro provides development tools for Clarity, and Clarity reference material is available in the Stacks ecosystem documentation.
+
+- [Clarity overview](https://docs.stacks.co/references/language-overview)
+- [Clarity types](https://docs.stacks.co/references/language-types)
+- [Clarity keywords](https://docs.stacks.co/references/language-keywords)
+- [Clarity functions](https://docs.stacks.co/references/language-functions)
+
+## Frontend development
+
+Hiro provides the Stacks.js libraries for developing Stacks web apps in JavaScript or TypeScript. Stacks.js consists of several libraries for interacting with the Stacks blockchain. The [connect](https://github.com/blockstack/connect#readme) library allows you to interact with the Hiro web wallet, allowing you to read important user information. The [transactions](https://github.com/blockstack/stacks.js/tree/master/packages/transactions) library has helper functions for converting JavaScript types to Clarity types (and vice versa), as well as functions for for forming Stacks transactions.
+
+For a full list of Stacks.js libraries, see the sidebar.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -3,4 +3,6 @@ id: tutorials
 title: Tutorials
 ---
 
-Welcome to Stacks development tutorials.
+The tutorials listed on this page provide real-world examples of developing Clarity contracts using Hiro developer tools. The primary development environment for Clarity is [Clarinet](https://github.com/hirosystems/clarinet), a comprehensive app for building and testing Clarity smart contracts. The provided tutorials are focused on getting a local development environment up and running, and exercising various features of Clarinet.
+
+For resources on learning the Clarity language, see the [Stacks ecosystem documentation](https://docs.stacks.co) and [Clarity Universe](https://stacks.org/clarity-universe).

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
+      title={`${siteConfig.title}`}
       description="Description will go into a meta tag in <head />"
     >
       <HomepageHeader />


### PR DESCRIPTION
## Description

This PR adds text content to the overview pages of the Hiro developer docs.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
