### PR TITLE
feat: enable docs-only mode and fix links

### DIFF
--- a/docs/build-apps/authentication.md
+++ b/docs/build-apps/authentication.md
@@ -5,11 +5,11 @@ title: Authenticating users
 
 This guide explains how to authenticate users with the [`connect`](https://github.com/blockstack/connect#readme) package of Stacks.js.
 
-Authentication provides a way for users to identify themselves to an app while retaining complete control over their credentials and personal details. It can be integrated alone or used in conjunction with [transaction signing](/docs/build-apps/transaction-signing) and [data storage](/docs/build-apps/data-storage), for which it is a prerequisite.
+Authentication provides a way for users to identify themselves to an app while retaining complete control over their credentials and personal details. It can be integrated alone or used in conjunction with [transaction signing](/build-apps/transaction-signing) and [data storage](/build-apps/data-storage), for which it is a prerequisite.
 
 Users who register for your app can subsequently authenticate to any other app with support for the [Blockchain Naming System](https://docs.stacks.co/build-apps/references/bns) and vice versa.
 
-See the [To-dos example app](/docs/example-apps/to-dos) for a concrete example of this feature in practice.
+See the [To-dos example app](/example-apps/to-dos) for a concrete example of this feature in practice.
 
 ## How it works
 
@@ -37,7 +37,7 @@ The authenticator generates the app private key from the user's _identity addres
 
 Finally, the app private key is deterministic, meaning that the same private key will always be generated for a given Stacks address and domain.
 
-The first two of these functions are particularly relevant to [data storage with Stacks.js](/docs/build-apps/data-storage).
+The first two of these functions are particularly relevant to [data storage with Stacks.js](/build-apps/data-storage).
 
 [Learn more about keypairs](#key-pairs) used by authentication.
 

--- a/docs/build-apps/integrate-stacking.md
+++ b/docs/build-apps/integrate-stacking.md
@@ -15,7 +15,7 @@ This tutorial highlights the following capabilities:
 
 :::tip
 
-Alternatively to integration using JS libraries, you can use the [Rust CLI](https://gist.github.com/kantai/c261ca04114231f0f6a7ce34f0d2499b) or [JS CLI](/docs/tutorials/stacking-using-CLI).
+Alternatively to integration using JS libraries, you can use the [Rust CLI](https://gist.github.com/kantai/c261ca04114231f0f6a7ce34f0d2499b) or [JS CLI](/tutorials/stacking-using-CLI).
 
 :::
 
@@ -255,7 +255,7 @@ The transaction completion will take several minutes. Only one stacking transact
 
 ## Step 6: Confirm lock-up
 
-The new transaction will not be completed immediately. It'll stay in the `pending` status for a few minutes. We need to poll the status and wait until the transaction status changes to `success`. We can use the [Stacks Blockchain API client library](/docs/get-started/stacks-blockchain-api#javascript-client-library) to check transaction status.
+The new transaction will not be completed immediately. It'll stay in the `pending` status for a few minutes. We need to poll the status and wait until the transaction status changes to `success`. We can use the [Stacks Blockchain API client library](/get-started/stacks-blockchain-api#javascript-client-library) to check transaction status.
 
 ```js
 const { TransactionsApi } = require("@stacks/blockchain-api-client");

--- a/docs/build-apps/transaction-signing.md
+++ b/docs/build-apps/transaction-signing.md
@@ -307,7 +307,7 @@ Each transaction signing method is itself available as a function returned by `u
 - `openSTXTransfer` as `doSTXTransfer`
 - `openContractDeploy` as `doContractDeploy`
 
-Use these functions with the same parameters as outlined above. However, you don't have to specify `appDetails` since they are detected automatically if `useConnect` has been used already [for authentication](/docs/build-apps/authentication#usage-in-react-apps).
+Use these functions with the same parameters as outlined above. However, you don't have to specify `appDetails` since they are detected automatically if `useConnect` has been used already [for authentication](/build-apps/authentication#usage-in-react-apps).
 
 ```tsx
 import { useConnect } from "@stacks/connect-react";
@@ -338,7 +338,7 @@ These payloads are tokens that conform to the [JSON Web Token (JWT) standard](ht
 
 ### Transaction Request Payload
 
-When an application triggers an transaction from `@stacks/connect`, the options of that transaction are serialized into a `transactionRequest` payload. The `transactionRequest` is similar to the [authRequest](/docs/build-apps/authentication#authrequest-payload-schema) payload used for authentication.
+When an application triggers an transaction from `@stacks/connect`, the options of that transaction are serialized into a `transactionRequest` payload. The `transactionRequest` is similar to the [authRequest](/build-apps/authentication#authrequest-payload-schema) payload used for authentication.
 
 The transaction request payload has the following schema, in addition to the standard JWT required fields:
 

--- a/docs/example-apps.md
+++ b/docs/example-apps.md
@@ -7,8 +7,8 @@ The example apps provided in this section demonstrate key features of the Stacks
 
 You can use the example apps provided here as a basis for your own Stacks app, or just as a reference for how Hirodevelopers implement specific features.
 
-- [To-dos](/docs/example-apps/to-dos): A to-do list app that demonstrates authentication with the web wallet and storing data off-chain with Gaia.
-- [Public registry](/docs/example-apps/public-registry): A extension of the to-do list that makes your list public through a Clarity smart contract.
-- [Billboard](/docs/example-apps/billboard): An app that stores a simple message on the blockchain and allows you to view it. Demonstrates the DevNet local development environment of [Clarinet](https://github.com/hirosystems/clarinet).
-- [Heystack](/docs/example-apps/heystack): A public chat app featuring a comprehensive demonstraction of the web wallet, Clarity smart contracts, and the Stacks API.
-- [Angular app](/docs/example-apps/angular): An exploration of the [connect](https://github.com/blockstack/connect#readme) library from Stacks.js using the Angular framework (rather than React)
+- [To-dos](/example-apps/to-dos): A to-do list app that demonstrates authentication with the web wallet and storing data off-chain with Gaia.
+- [Public registry](/example-apps/public-registry): A extension of the to-do list that makes your list public through a Clarity smart contract.
+- [Billboard](/example-apps/billboard): An app that stores a simple message on the blockchain and allows you to view it. Demonstrates the DevNet local development environment of [Clarinet](https://github.com/hirosystems/clarinet).
+- [Heystack](/example-apps/heystack): A public chat app featuring a comprehensive demonstraction of the web wallet, Clarity smart contracts, and the Stacks API.
+- [Angular app](/example-apps/angular): An exploration of the [connect](https://github.com/blockstack/connect#readme) library from Stacks.js using the Angular framework (rather than React)

--- a/docs/example-apps/angular.md
+++ b/docs/example-apps/angular.md
@@ -3,7 +3,7 @@ id: angular
 title: Angular authenticator
 ---
 
-In this tutorial, you'll learn how to work with Stacks Connect when using [Angular](https://angular.io/) as your framework of choice. It builds on what you've learnt in the [Authentication Overview](/docs/build-apps/authentication).
+In this tutorial, you'll learn how to work with Stacks Connect when using [Angular](https://angular.io/) as your framework of choice. It builds on what you've learnt in the [Authentication Overview](/build-apps/authentication).
 
 :::note
 
@@ -123,7 +123,7 @@ Here we're using an Rxjs `Subject` to represent a stream of sign in events. `sta
 
 ### Authentication
 
-First, describe the auth options we need to pass to Connect. [Learn more about `AuthOptions` here](/docs/build-apps/authentication). Let's modify the default component to look like this:
+First, describe the auth options we need to pass to Connect. [Learn more about `AuthOptions` here](/build-apps/authentication). Let's modify the default component to look like this:
 
 ```typescript
 import { Component } from "@angular/core";

--- a/docs/example-apps/billboard.md
+++ b/docs/example-apps/billboard.md
@@ -3,14 +3,14 @@ id: billboard
 title: Billboard app
 ---
 
-This example app demonstrates the integration between a simple web app and a Clarity smart contract. Using the [DevNet](/docs/smart-contracts/devnet), a local version of the Stacks blockchain is used as a development and integration environment for the full stack app. This app builds a frontend to the [Billboard smart contract](/docs/tutorials/clarity-billboard), and demonstrates the use of the [Stacks API](/api) in React. The full source of the app is provided and is completely open source for you to modify. This page is a case study highlighting important code snippets and design patterns to help you develop your own Stacks app, as well as use the DevNet feature to integrate your frontend and backend without deploying to a live testnet.
+This example app demonstrates the integration between a simple web app and a Clarity smart contract. Using the [DevNet](/smart-contracts/devnet), a local version of the Stacks blockchain is used as a development and integration environment for the full stack app. This app builds a frontend to the [Billboard smart contract](/tutorials/clarity-billboard), and demonstrates the use of the [Stacks API](/api) in React. The full source of the app is provided and is completely open source for you to modify. This page is a case study highlighting important code snippets and design patterns to help you develop your own Stacks app, as well as use the DevNet feature to integrate your frontend and backend without deploying to a live testnet.
 
 This app showcases the following features of Stacks and Clarinet:
 
 - Running a local Stacks blockchain (DevNet)
 - Storing values in a Clarity smart contract
 - Accessing values in a smart contract from the [Stacks API](/api)
-- Issuing a contract transaction with [Stacks.js](/docs/references#frontend-development)
+- Issuing a contract transaction with [Stacks.js](/references#frontend-development)
 
 The source for the billboard app is available on [GitHub](https://github.com/pgray-hiro/stacks-billboard). This page assumes that you have familiarity with [React](https://reactjs.org).
 
@@ -28,7 +28,7 @@ If you are interested in running the billboard app locally, you can follow the i
 
 ## Review billboard contract
 
-The backend of the billboard app is a Clarity smart contract. The billboard contract stores the billboard message, and defines the functions for updating the message. For a complete overview of how to develop the billboard contract, review the [billboard tutorial](/docs/tutorials/clarity-billboard).
+The backend of the billboard app is a Clarity smart contract. The billboard contract stores the billboard message, and defines the functions for updating the message. For a complete overview of how to develop the billboard contract, review the [billboard tutorial](/tutorials/clarity-billboard).
 
 The Clarity smart contract for this app is located at `/contracts/billboard.clar`. It defines 3 functions, `get-price`, `get-message`, and `set-message`. This example app only demonstrates the interaction with the latter two functions, however you could extend the app to get the message price using the same general design for interacting with the `get-message` function.
 
@@ -84,9 +84,9 @@ To avoid errors, it is recommended that you bring up the local DevNet and allow 
 
 ### DevNet configuration
 
-DevNet is a highly configurable instance of the Stacks blockchain. You can configure many of the properties of the DevNet through modifying values in the `settings/DevNet.toml` file. When you create a new project with Clarinet, this file is populated with sensible default vales for the local blockchain. If you would like to [change any of the default values](/docs/smart-contracts/devnet#blockchain-configuration), uncomment the line containing the configuration parameter, and change the value to your intended configuration.
+DevNet is a highly configurable instance of the Stacks blockchain. You can configure many of the properties of the DevNet through modifying values in the `settings/DevNet.toml` file. When you create a new project with Clarinet, this file is populated with sensible default vales for the local blockchain. If you would like to [change any of the default values](/smart-contracts/devnet#blockchain-configuration), uncomment the line containing the configuration parameter, and change the value to your intended configuration.
 
-The DevNet configuration file also contains [definitions for predefined wallets](/docs/smart-contracts/devnet#accounts-configuration) in the local chain. These wallets are pre-populated with STX tokens, and can be used for testing and integration. The configuration file provides the seed phrase and private key for each wallet as well.
+The DevNet configuration file also contains [definitions for predefined wallets](/smart-contracts/devnet#accounts-configuration) in the local chain. These wallets are pre-populated with STX tokens, and can be used for testing and integration. The configuration file provides the seed phrase and private key for each wallet as well.
 
 ## Running the billboard frontend
 
@@ -250,6 +250,6 @@ const transaction = makeContractCall(txOptions)
 
 :::note
 
-This simple command-line script is provided as an additional demonstration of transactions, you could also update the message using the [Stacks CLI](/docs/get-started/command-line-interface).
+This simple command-line script is provided as an additional demonstration of transactions, you could also update the message using the [Stacks CLI](/get-started/command-line-interface).
 
 :::

--- a/docs/example-apps/public-registry.md
+++ b/docs/example-apps/public-registry.md
@@ -3,9 +3,9 @@ id: public-registry
 title: Public registry app
 ---
 
-The [Stacks Blockchain API](/docs/get-started/stacks-blockchain-api) is an API that helps app developers to view and use the state of the Stacks blockchain.
+The [Stacks Blockchain API](/get-started/stacks-blockchain-api) is an API that helps app developers to view and use the state of the Stacks blockchain.
 
-In this tutorial you will extend [the To-dos app](/docs/example-apps/to-dos) to share individual lists publicly using the Stacks blockchain.
+In this tutorial you will extend [the To-dos app](/example-apps/to-dos) to share individual lists publicly using the Stacks blockchain.
 
 The registry of shared to-dos lists is implemented by a Clarity smart contract named [`todo-registry`](https://github.com/friedger/blockstack-todos/blob/tut/public-registry/contracts/todo-registry.clar). Data from this contract will be shown in the to-dos app.
 
@@ -30,7 +30,7 @@ Furthermore, the to-dos app will interact with a smart contract deployed as `ST1
 
 There may already be a deployed version available on the testnet; the [Stacks Explorer](https://explorer.stacks.co/) can be used to search for it.
 
-Alternatively, the contract can be deployed as described in the [hello world tutorial](/docs/tutorials/clarity-hello-world). Then you have to use the corresponding contract address and name in this tutorial. Throughout this tutorial, we use `ST3YPJ6BBCZCMH71TV8BK50YC6QJTWEGCNDFWEQ15.todo-registry` as an example.
+Alternatively, the contract can be deployed as described in the [hello world tutorial](/tutorials/clarity-hello-world). Then you have to use the corresponding contract address and name in this tutorial. Throughout this tutorial, we use `ST3YPJ6BBCZCMH71TV8BK50YC6QJTWEGCNDFWEQ15.todo-registry` as an example.
 
 ### Tutorials
 
@@ -116,7 +116,7 @@ export const PublicUrlRegistrar = ({ userSession }) => {
 };
 ```
 
-It is a simple button that calls `doContractCall` method of the Connect library when clicked. The method makes an api call to the Stacks authenticator. The authenticator creates a contract call transaction that is signed by the user and then it is broadcast to the Stacks blockchain as explained in the [transaction signing tutorial](/docs/build-apps/transaction-signing).
+It is a simple button that calls `doContractCall` method of the Connect library when clicked. The method makes an api call to the Stacks authenticator. The authenticator creates a contract call transaction that is signed by the user and then it is broadcast to the Stacks blockchain as explained in the [transaction signing tutorial](/build-apps/transaction-signing).
 
 Note how the arguments are created using `bufferCVFromString`. There are similar methods for all other Clarity types, like `uintCV` or `trueCV`. See the [documentation](https://github.com/blockstack/stacks.js/tree/master/packages/transactions#constructing-clarity-values) of the stacks-transactions library for more details.
 
@@ -462,7 +462,7 @@ Congratulations. You just implemented a list of recent activities that was fetch
 
 ## Fetch the first to-dos list
 
-There are two other ways to get state information from the blockchain: read-only functions and data map entries. Read-only functions were already discussed in the [Clarity counter tutorial](/docs/tutorials/clarity-counter). They do not require a transaction to complete. Data maps in Clarity are maps that can be read by any user. See the [Clarity reference](https://docs.stacks.co/references/language-functions#define-map) for more details.
+There are two other ways to get state information from the blockchain: read-only functions and data map entries. Read-only functions were already discussed in the [Clarity counter tutorial](/tutorials/clarity-counter). They do not require a transaction to complete. Data maps in Clarity are maps that can be read by any user. See the [Clarity reference](https://docs.stacks.co/references/language-functions#define-map) for more details.
 
 The `todo-registry` contract defines a read-only function `owner-of?` that returns the owner of a registry entry and a data map for details about entries:
 

--- a/docs/example-apps/todos.md
+++ b/docs/example-apps/todos.md
@@ -107,7 +107,7 @@ The `showConnect` function accepts a number of properties within a parameter obj
 
 - The app's `name` and `icon`: provided as strings comprising the `appDetails` object property.
 - The `redirectTo` string: used to provide a URL to which the user should be redirected upon successful authentication. The `onFinish` callback serves a similar purpose by handling successful authentication within a context of a popup window.
-- The `userSession` object: used to pass the [scopes](/docs/build-apps/authentication#initiate-usersession-object) needed by the app.
+- The `userSession` object: used to pass the [scopes](/build-apps/authentication#initiate-usersession-object) needed by the app.
 
 Note how the `userSession` object is created at the beginning of this module by leveraging an `AppConfig` object that's first initiated with all relevant scopes.
 

--- a/docs/get-started/running-mainnet-node.md
+++ b/docs/get-started/running-mainnet-node.md
@@ -170,6 +170,6 @@ docker stop stacks-blockchain
 
 - [Running an API instance with Docker][]
 
-[running a testnet node with docker]: /docs/get-started/running-testnet-node
-[running an api instance with docker]: /docs/get-started/running-api-node
+[running a testnet node with docker]: /get-started/running-testnet-node
+[running an api instance with docker]: /get-started/running-api-node
 [`stacks-blockchain`]: https://github.com/blockstack/stacks-blockchain

--- a/docs/get-started/running-testnet-node.md
+++ b/docs/get-started/running-testnet-node.md
@@ -141,6 +141,6 @@ docker stop stacks-blockchain
 
 - [Running an API instance with Docker][]
 
-[running a mainnet node with docker]: /docs/get-started/running-mainnet-node
-[running an api instance with docker]: /docs/get-started/running-api-node
+[running a mainnet node with docker]: /get-started/running-mainnet-node
+[running an api instance with docker]: /get-started/running-api-node
 [`stacks-blockchain`]: https://github.com/blockstack/stacks-blockchain

--- a/docs/get-started/stacks-blockchain-api.md
+++ b/docs/get-started/stacks-blockchain-api.md
@@ -43,7 +43,7 @@ The easiest way to start interacting with the API is through the [Postman Collec
 
 :::info
 
-Postman allows you to [generate sample code](https://learning.postman.com/docs/sending-requests/generate-code-snippets/) for API requests for various languages and libraries
+Postman allows you to [generate sample code](https://learning.postman.com/sending-requests/generate-code-snippets/) for API requests for various languages and libraries
 
 :::
 
@@ -51,7 +51,7 @@ Postman allows you to [generate sample code](https://learning.postman.com/docs/s
 
 The Stacks API was designed using the [OpenAPI specification](https://swagger.io/specification/), making it compatible with a variety of developer tools.
 
-The [OpenAPI specification file for Stacks](https://github.com/blockstack/stacks-blockchain-api/blob/master/docs/openapi.yaml) is used to generate the [TypeScript client library](#typescript-client-library). You can use the specification file to generate client libraries for other programming languages using the [openapi-generator tool](https://github.com/OpenAPITools/openapi-generator)
+The [OpenAPI specification file for Stacks](https://github.com/blockstack/stacks-blockchain-api/blob/master/openapi.yaml) is used to generate the [TypeScript client library](#typescript-client-library). You can use the specification file to generate client libraries for other programming languages using the [openapi-generator tool](https://github.com/OpenAPITools/openapi-generator)
 
 ## TypeScript client library
 
@@ -394,7 +394,7 @@ You can use the `possible_next_nonce` property as the nonce for your next transa
 
 ## Running an API server
 
-While Hiro provides a hosted API server of the Stacks Blockchain API, anyone can spin up their own version. Please [follow the instructions in this guide](/docs/get-started/running-api-node) to start a Docker container with the API service running.
+While Hiro provides a hosted API server of the Stacks Blockchain API, anyone can spin up their own version. Please [follow the instructions in this guide](/get-started/running-api-node) to start a Docker container with the API service running.
 
 :::info
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -7,7 +7,7 @@ The resources in this section are provided for reference toward developer resour
 
 ## Interacting with the blockchain
 
-The [Stacks CLI](/docs/references/stacks-cli) provides an easy way for you to interact with the Stacks live blockchain (testnet or mainnet). The CLI can be used to test transactions, perform stacking, or deploy contracts. Since the Stacks CLI operates on unencrypted private keys, it is recommended that you use the CLI as a development tool only, and not against accounts with significant amounts of mainnet STX tokens.
+The [Stacks CLI](/references/stacks-cli) provides an easy way for you to interact with the Stacks live blockchain (testnet or mainnet). The CLI can be used to test transactions, perform stacking, or deploy contracts. Since the Stacks CLI operates on unencrypted private keys, it is recommended that you use the CLI as a development tool only, and not against accounts with significant amounts of mainnet STX tokens.
 
 ## Contract development
 

--- a/docs/smart-contracts/devnet.md
+++ b/docs/smart-contracts/devnet.md
@@ -153,6 +153,6 @@ stacking orders that are necessary for your configuration.
 - `slots`: the number of stacking slots that the wallet will participate in
 - `btc_address`: the BTC address that stacking rewards should be sent to
 
-[clarinet installed]: /docs/smart-contracts/clarinet#installing-clarinet
+[clarinet installed]: /smart-contracts/clarinet#installing-clarinet
 [docker documentation]: https://docs.docker.com/get-docker/
 [stacking orders]: #stacking-orders

--- a/docs/tutorials/clarity-billboard.md
+++ b/docs/tutorials/clarity-billboard.md
@@ -302,9 +302,9 @@ You have now learned how to store and update data on chain with a variable, and 
 a contract caller to a new principal address. Additionally, you have learned how to write a unit test for a simple
 Clarity contract using Clarinet.
 
-[counter tutorial]: /docs/tutorials/clarity-counter
-[clarinet]: /docs/smart-contracts/clarinet
-[installing clarinet]: /docs/smart-contracts/clarinet#installing-clarinet
+[counter tutorial]: /tutorials/clarity-counter
+[clarinet]: /smart-contracts/clarinet
+[installing clarinet]: /smart-contracts/clarinet#installing-clarinet
 [visual studio code]: https://code.visualstudio.com/
 [final code for this tutorial]: https://github.com/hirosystems/clarinet/tree/master/examples/billboard
 [`let`]: https://docs.stacks.co/references/language-functions#let

--- a/docs/tutorials/clarity-counter.md
+++ b/docs/tutorials/clarity-counter.md
@@ -241,16 +241,16 @@ Try calling the other public functions from the [call a contract][] page.
 You have now learned one method of deploying and interacting with smart contracts on Stacks. You have also learned
 the strengths of performing local development without having to wait for block times.
 
-[hello world tutorial]: /docs/tutorials/clarity-hello-world
-[clarinet]: /docs/smart-contracts/clarinet
-[installing clarinet]: /docs/smart-contracts/clarinet#installing-clarinet
+[hello world tutorial]: /tutorials/clarity-hello-world
+[clarinet]: /smart-contracts/clarinet
+[installing clarinet]: /smart-contracts/clarinet#installing-clarinet
 [`define-data-var`]: https://docs.stacks.co/references/language-functions#define-data-var
 [testnet sandbox]: https://explorer.stacks.co/sandbox/deploy?chain=testnet
 [stacks web wallet]: https://www.hiro.so/wallet/install-web
 [testnet faucet]: https://explorer.stacks.co/sandbox/faucet?chain=testnet
-[unit tests]: /docs/smart-contracts/clarinet#testing-with-clarinet
+[unit tests]: /smart-contracts/clarinet#testing-with-clarinet
 [`var-get`]: https://docs.stacks.co/references/language-functions#var-get
-[`clarinet console`]: /docs/smart-contracts/clarinet#testing-with-the-console
+[`clarinet console`]: /smart-contracts/clarinet#testing-with-the-console
 [`begin`]: https://docs.stacks.co/references/language-functions#begin
 [`var-set`]: https://docs.stacks.co/references/language-functions#var-set
 [`+`]: https://docs.stacks.co/references/language-functions#-add

--- a/docs/tutorials/clarity-hello-world.md
+++ b/docs/tutorials/clarity-hello-world.md
@@ -252,14 +252,14 @@ wallet. The transaction summary page displays the output of the function:
 You have now learned one method of deploying and interacting with smart contracts on Stacks. You have also learned
 the strengths of performing local development without having to wait for block times.
 
-[clarinet]: /docs/smart-contracts/clarinet
-[installing clarinet]: /docs/smart-contracts/clarinet#installing-clarinet
+[clarinet]: /smart-contracts/clarinet
+[installing clarinet]: /smart-contracts/clarinet#installing-clarinet
 [clarity.tools]: https://clarity.tools
 [testnet sandbox]: https://explorer.stacks.co/sandbox/deploy?chain=testnet
 [stacks web wallet]: https://www.hiro.so/wallet/install-web
 [testnet faucet]: https://explorer.stacks.co/sandbox/faucet?chain=testnet
 [step 3]: #step-3-add-code-to-the-hello-world-contract
-[unit tests]: /docs/smart-contracts/clarinet#testing-with-clarinet
+[unit tests]: /smart-contracts/clarinet#testing-with-clarinet
 [separating concerns]: https://en.wikipedia.org/wiki/Separation_of_concerns
 [`ok`]: https://docs.stacks.co/references/language-functions#ok
 [read-only function]: https://docs.stacks.co/references/language-functions#define-read-only

--- a/docs/tutorials/clarity-nft.md
+++ b/docs/tutorials/clarity-nft.md
@@ -25,7 +25,7 @@ In this tutorial you will:
 
 ## Prerequisites
 
-For this tutorial, you should have a local installation of Clarinet. Refer to [Installing Clarinet](/docs/smart-contracts/clarinet#installing-clarinet)
+For this tutorial, you should have a local installation of Clarinet. Refer to [Installing Clarinet](/smart-contracts/clarinet#installing-clarinet)
 for instructions on how to set up your local environment. You should also have a text editor or IDE to edit the Clarity
 smart contracts.
 
@@ -44,7 +44,7 @@ request the tokens before beginning the tutorial.
 
 ## Step 1: Create a new project
 
-With [Clarinet installed locally](/docs/smart-contracts/clarinet#installing-clarinet), open a terminal window and
+With [Clarinet installed locally](/smart-contracts/clarinet#installing-clarinet), open a terminal window and
 create a new Clarinet project with the command:
 
 ```sh

--- a/docs/tutorials/sending-tokens.md
+++ b/docs/tutorials/sending-tokens.md
@@ -39,13 +39,13 @@ npm install --save @stacks/transactions bn.js @stacks/blockchain-api-client cros
 
 :::info
 
-The API client is generated from the [OpenAPI specification](https://github.com/blockstack/stacks-blockchain-api/blob/master/docs/openapi.yaml) ([openapi-generator](https://github.com/OpenAPITools/openapi-generator)). Many other languages and frameworks are be supported by the generator.
+The API client is generated from the [OpenAPI specification](https://github.com/blockstack/stacks-blockchain-api/blob/master/openapi.yaml) ([openapi-generator](https://github.com/OpenAPITools/openapi-generator)). Many other languages and frameworks are be supported by the generator.
 
 :::
 
 ## Step 2: Specifying a sender
 
-In order to build and sign transactions, you will need a Stacks private key. You can easily generate a new, random Stacks 2.0 sender key (see ["Generating an account" from the previous tutorial](/docs/tutorials/managing-accounts#step-2-generating-an-account)).
+In order to build and sign transactions, you will need a Stacks private key. You can easily generate a new, random Stacks 2.0 sender key (see ["Generating an account" from the previous tutorial](/tutorials/managing-accounts#step-2-generating-an-account)).
 
 For this tutorial, we will use an existing Stacks account and instantiate the key object from a private key string:
 
@@ -246,4 +246,4 @@ For all property formats and details, please review the [API reference](https://
 
 ## Step 6: Confirming balance (optional)
 
-Now that the token transfer is confirmed, we can verify the new account balance on the sender address by [following the "Getting account balances" steps from the previous tutorial](/docs/tutorials/managing-accounts#step-5-getting-account-balances).
+Now that the token transfer is confirmed, we can verify the new account balance on the sender address by [following the "Getting account balances" steps from the previous tutorial](/tutorials/managing-accounts#step-5-getting-account-balances).

--- a/docs/tutorials/stacking-using-cli.md
+++ b/docs/tutorials/stacking-using-cli.md
@@ -61,7 +61,7 @@ curl -X POST https://stacks-node-api.xenon.blockstack.org/extended/v1/faucets/st
 
 ## Check Balance
 
-Confirm that the faucet transaction has completed by checking the balance of your address. The `-t` flag is used to indicate testnet. See the [CLI reference](/docs/references/stacks-cli) for usage of flags.
+Confirm that the faucet transaction has completed by checking the balance of your address. The `-t` flag is used to indicate testnet. See the [CLI reference](/references/stacks-cli) for usage of flags.
 
 ```bash
 stx balance ST1P3HXR80TKT48TKM2VTKCDBS4ET9396W0W2S3K8 -t
@@ -144,4 +144,4 @@ stx stacking_status ST1P3HXR80TKT48TKM2VTKCDBS4ET9396W0W2S3K8 -t
 
 Here we can see how many microstacks are locked and when they will unlock.
 
-Congratulations you have learned how to Stack using the CLI. To integrate Stacking into your app, check out the [Stacking integration guide](/docs/build-apps/integrate-stacking).
+Congratulations you have learned how to Stack using the CLI. To integrate Stacking into your app, check out the [Stacking integration guide](/build-apps/integrate-stacking).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,6 +27,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
             sidebarPath: require.resolve("./sidebars.js"),
             // Please change this to your repo.
             editUrl: "https://github.com/hirosystems/docs/edit/main/",
+            routeBasePath: "/",
           },
           theme: {
             customCss: require.resolve("./src/css/custom.css"),
@@ -100,7 +101,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
               items: [
                 {
                   label: "Developer docs",
-                  to: "/docs/intro",
+                  to: "/intro",
                 },
                 {
                   label: "Stacks API",
@@ -108,11 +109,11 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
                 },
                 {
                   label: "Tutorials",
-                  to: "/docs/tutorials",
+                  to: "/tutorials",
                 },
                 {
                   label: "Example apps",
-                  to: "/docs/example-apps",
+                  to: "/example-apps",
                 },
               ],
             },


### PR DESCRIPTION
## Description

This PR enables docs-only mode, which removes the additional `docs` string from the URL of the content. This was requested because the URL `docs.hiro.so/docs/intro` is clunky with the repeated string. This PR also updates all the links within the markdown content so that they are not broken.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
