### PR TITLE
fix: typo

### DIFF
--- a/docs/tutorials/clarity-billboard.md
+++ b/docs/tutorials/clarity-billboard.md
@@ -210,7 +210,7 @@ At this point, the final contract should look like this:
 
 Use `clarinet check` to ensure that your Clarity code is well-formed and error-free.
 
-## Step 5: write a contract test
+## Step 5: Write a contract test
 
 At this point, the contract functions as intended, and can be deployed to the blockchain. However, it's good practice
 to write automated testing to ensure that the contract functions perform in the expected way. Testing can be valuable


### PR DESCRIPTION
## Description

Fix a minor typo in the heading of the Billboard smart contract tutorial.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
