### PR TITLE
fix: pointed Discord link to Stacks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,7 +149,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
               items: [
                 {
                   label: "Discord",
-                  href: "https://discordapp.com/invite/docusaurus",
+                  href: "https://stacks.chat",
                 },
                 {
                   label: "Stacks Forum",


### PR DESCRIPTION
## Description

This PR fixes the Discord link in the footer so that it no longer points at the Docusaurus Discord server.

Closes #42 

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
