### PR TITLE
fix(docs): Add missing parentheses

### DIFF
--- a/docs/tutorials/clarity-nft.md
+++ b/docs/tutorials/clarity-nft.md
@@ -152,7 +152,7 @@ following code into the file.
   (begin 
     (try! (transfer token-id sender recipient))
     (print memo)
-    (ok true))
+    (ok true)))
 
 ;; SIP009: Get the owner of the specified token ID
 (define-read-only (get-owner (token-id uint))


### PR DESCRIPTION
## Description

When running `clarity check` I get the following error:

  Unfinished stack: 1 items remaining starting at (21, 1)
  my-nft:21:1: error: List expressions (..) left opened.

Added the missing parentheses to the method in `transfer-memo`.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
