### PR TITLE
fix: add missing backslash for practicable Postgres on Docker

### DIFF
--- a/docs/get-started/running-api-node.md
+++ b/docs/get-started/running-api-node.md
@@ -87,7 +87,7 @@ docker run -d --rm \
   --net=stacks-blockchain \
   -e POSTGRES_PASSWORD=postgres \
   -v $(pwd)/persistent-data/postgres:/var/lib/postgresql/data \
-  -p 5432:5432
+  -p 5432:5432 \
   postgres:alpine
 ```
 


### PR DESCRIPTION
## Description

Describe the changes that were made in this pull request. When possible start with the motivations behind the change. Be sure to also include the following information:

1. Motivation for change? Failed to execute Postgres on Docker
2. What was changed? I've added backslash on practicable code for running Postgres on Docker
3. Link to relevant issues? no, because it's small change

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
