### PR TITLE
Add Hiro newletter links to header/footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,6 +90,11 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
               label: "Example Apps",
             },
             {
+              to: "https://hiro.so/updates-docs",
+              label: "Get Updates",
+              position: "left",
+            },
+            {
               href: 'https://github.com/hirosystems/docs',
               position: 'right',
               className: 'header-github-link',
@@ -143,6 +148,10 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
                 {
                   label: "Youtube",
                   href: "https://www.youtube.com/channel/UC3xNLj2Mu7fW-BCq-vC9xKQ",
+                },
+                {
+                  label: "Newsletter",
+                  href: "https://hiro.so/updates-docs",
                 },
               ],
             },


### PR DESCRIPTION
Per #95, we are adding Hiro's newsletter link as a top-level tab and a link in the footer, so developers and documentation readers can subscribe to the news and product updates.
