### PR TITLE
Fix terminology in build app message signing doc

### DIFF
--- a/docs/build-apps/message-signing.md
+++ b/docs/build-apps/message-signing.md
@@ -11,7 +11,7 @@ The user can then click on the ‘Sign’ button which will return the signature
 
 The message can be any utf-8 string.
 
-Internally the string will be hashed using `sha256` and signed with `secp256k1` using the user's publicKey
+Internally the string will be hashed using `sha256` and signed with `secp256k1` using the user's privateKey
 
 ## Install dependency
 


### PR DESCRIPTION
Minor fix that confused me while reading through the docs:

- Fix terminology in build app message signing doc