### PR TITLE
clarinet.toml config update

### DIFF
--- a/docs/smart-contracts/clarinet.md
+++ b/docs/smart-contracts/clarinet.md
@@ -110,7 +110,6 @@ This command creates a new `my-contract.clar` file in the `contracts` directory,
 ```toml
 [contracts.my-contract]
 path = "contracts/my-contract.clar"
-depends_on = []
 ```
 
 At this point, you can begin editing your smart contract in the `contracts` directory. At any point while you are


### PR DESCRIPTION
## Description


Removed `depends_on = []' in the Clarinet.toml file. 