### PR TITLE
Hide examples until when they are fully functional

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,12 +82,12 @@ module.exports = {
             position: 'left',
             label: 'Tutorials',
           },
-          {
-            type: 'doc',
-            docId: 'example-apps',
-            position: 'left',
-            label: 'Example Apps',
-          },
+          // {
+          //   type: 'doc',
+          //   docId: 'example-apps',
+          //   position: 'left',
+          //   label: 'Example Apps',
+          // },
           {
             to: 'https://hiro.so/updates-docs',
             label: 'Get Updates',
@@ -125,10 +125,10 @@ module.exports = {
                 label: 'Tutorials',
                 to: '/tutorials',
               },
-              {
-                label: 'Example Apps',
-                to: '/example-apps',
-              },
+              // {
+              //   label: 'Example Apps',
+              //   to: '/example-apps',
+              // },
             ],
           },
           {


### PR DESCRIPTION
## Description

Hide example applications until when they are entirely functional.

1. Motivation for change?

> None of the example apps work today, so hiding them until we revive and get them up and running (soon!).

2. What was changed?

> Commented out the top-level Examples tab.