### PR TITLE
Revive examples and add Node version requirements

### DIFF
--- a/docs/example-apps.md
+++ b/docs/example-apps.md
@@ -2,13 +2,16 @@
 id: example-apps
 title: Example apps
 ---
+import NodeLTS from './includes/node-lts-version.mdx';
 
 The example apps provided in this section demonstrate key features of the Stacks blockchain, including connecting to the wallet, reading on-chain values, creating transactions, and interacting with the web wallet.
 
-You can use the example apps provided here as a basis for your own Stacks app, or just as a reference for how Hirodevelopers implement specific features.
+:::note
+<NodeLTS/>
+:::
+
+You can use the example apps provided here as a basis for your own Stacks application or just as a reference for how to implement specific features.
 
 - [To-dos](/example-apps/to-dos): A to-do list app that demonstrates authentication with the web wallet and storing data off-chain with Gaia.
-- [Public registry](/example-apps/public-registry): A extension of the to-do list that makes your list public through a Clarity smart contract.
 - [Billboard](/example-apps/billboard): An app that stores a simple message on the blockchain and allows you to view it. Demonstrates the DevNet local development environment of [Clarinet](https://github.com/hirosystems/clarinet).
 - [Heystack](/example-apps/heystack): A public chat app featuring a comprehensive demonstraction of the web wallet, Clarity smart contracts, and the Stacks API.
-- [Angular app](/example-apps/angular): An exploration of the [connect](https://github.com/hirosystems/connect/) library from Stacks.js using the Angular framework (rather than React)

--- a/docs/example-apps/billboard.md
+++ b/docs/example-apps/billboard.md
@@ -2,6 +2,7 @@
 id: billboard
 title: Billboard app
 ---
+import NodeLTS from '../includes/node-lts-version.mdx';
 
 This example app demonstrates the integration between a simple web app and a Clarity smart contract. Using the [DevNet](/smart-contracts/devnet), a local version of the Stacks blockchain is used as a development and integration environment for the full stack app. This app builds a frontend to the [Billboard smart contract](/tutorials/clarity-billboard), and demonstrates the use of the [Stacks API](/api) in React. The full source of the app is provided and is completely open source for you to modify. This page is a case study highlighting important code snippets and design patterns to help you develop your own Stacks app, as well as use the DevNet feature to integrate your frontend and backend without deploying to a live testnet.
 
@@ -14,6 +15,10 @@ This app showcases the following features of Stacks and Clarinet:
 
 The source for the billboard app is available on [GitHub](https://github.com/hirosystems/stacks-billboard). This page assumes that you have familiarity with [React](https://reactjs.org).
 
+:::note
+<NodeLTS/>
+:::
+
 ## Billboard overview
 
 Billboard is a simple Stacks app that uses a Clarity smart contract to store a message on the Stacks blockchain. A web frontend built with React and Stacks.js then accesses and displays the message. The smart contract backend also has methods for updating the message through a small STX payment. The cost to update the message increases with each update.
@@ -23,8 +28,6 @@ Billboard is a simple Stacks app that uses a Clarity smart contract to store a m
 The billboard app is provided as a simple demonstration of a full stack Stacks web app, and an example of the architecture of a Stacks app. You can use the billboard app as a base for your own Stacks app, or review the code to learn more about how to structure your own full stack Stacks app.
 
 ### Quickstart
-
-If you are interested in running the billboard app locally, you can follow the instructions in the [GitHub README](https://github.com/pgray-hiro/stacks-billboard#readme). You should have Clarinet installed locally, and Node.js 12+ (Node 14 recommended).
 
 ## Review billboard contract
 

--- a/docs/example-apps/heystack.md
+++ b/docs/example-apps/heystack.md
@@ -2,6 +2,11 @@
 id: heystack
 title: Heystack chat app
 ---
+import NodeLTS from '../includes/node-lts-version.mdx';
+
+:::note
+<NodeLTS/>
+:::
 
 ## Introduction
 

--- a/docs/example-apps/todos.md
+++ b/docs/example-apps/todos.md
@@ -2,6 +2,7 @@
 id: to-dos
 title: To-dos app
 ---
+import NodeLTS from '../includes/node-lts-version.mdx';
 
 ![What you'll be studying in this tutorial](/img/todos-home.png)
 
@@ -19,10 +20,9 @@ This app highlights the following platform capabilities:
 
 Existing familiarity with [React](https://reactjs.org/) is recommended for reviewing this app's code.
 
-## Install and run the app
-
-You must have recent versions of Git and [Node.js](https://nodejs.org/en/download/)
-(v12.10.0 or greater) installed already.
+:::note
+<NodeLTS/>
+:::
 
 ### Step 1: Install the code and its dependencies
 

--- a/docs/includes/node-lts-version.mdx
+++ b/docs/includes/node-lts-version.mdx
@@ -1,0 +1,5 @@
+The example apps depend on a stable version of NodeJS. Install the LTS version of NodeJS using the [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating) with the following command.
+
+```sh
+nvm install --lts
+```

--- a/docs/includes/node-lts-version.mdx
+++ b/docs/includes/node-lts-version.mdx
@@ -1,4 +1,4 @@
-The example apps depend on a stable version of NodeJS. Install the LTS version of NodeJS using the [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating) with the following command.
+The example apps depend on a stable version of NodeJS. Install the LTS version of NodeJS using [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating) with the following command.
 
 ```sh
 nvm install --lts

--- a/sidebars.js
+++ b/sidebars.js
@@ -180,9 +180,7 @@ module.exports = {
   'example-apps': [
     'example-apps',
     'example-apps/to-dos',
-    'example-apps/public-registry',
     'example-apps/billboard',
     'example-apps/heystack',
-    'example-apps/angular',
   ],
 };


### PR DESCRIPTION
## Description

As described at https://github.com/hirosystems/docs/issues/119#issuecomment-1195965944, I propose adding a note about the Node requirements and fixing the relevant bits in the individual apps via https://github.com/hirosystems/heystack/pull/41 and https://github.com/hirosystems/todos/pull/109.

The `public-registry` and `angular` apps have been unlisted along with the above changes. More details in the comment on #119.

1. Motivation for change?

> Attempt to fix the examples that are broke and otherwise remain unhelpful to developers.

2. What was changed?

> Add NOTE to guide developers about the Node version.

3. Link to relevant issues?

> Fixes https://github.com/hirosystems/docs/issues/119. Depends on https://github.com/hirosystems/heystack/pull/41 and https://github.com/hirosystems/todos/pull/109.