### PR TITLE
Docs |  Remove developer survey logo | 27th Sep 2022.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,12 +106,6 @@ module.exports = {
             position: 'left',
           },
           {
-            to: 'https://survey.hiro.so',
-            label: 'Take The Dev Survey',
-            className: 'header-survey-link',
-            position: 'left',
-          },
-          {
             href: 'https://github.com/hirosystems/docs',
             position: 'right',
             className: 'header-github-link',


### PR DESCRIPTION
Removed the "Take the Dev survey" logo from the docs home page.