### PR TITLE
Added link to token metadata service

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,7 +83,7 @@ module.exports = {
               },
               {
                 label: 'Token Metadata Service',
-                to: 'https://token-metadata-service-dlkidjgff-blockstack.vercel.app/',
+                href: 'https://token-metadata-service-dlkidjgff-blockstack.vercel.app/',
               },
               {
                 label: 'Stacks CLI',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,6 +82,10 @@ module.exports = {
                 to: '/api',
               },
               {
+                label: 'Token Metadata Service',
+                to: 'https://token-metadata-service-dlkidjgff-blockstack.vercel.app/',
+              },
+              {
                 label: 'Stacks CLI',
                 to: '/references/stacks-cli',
               },


### PR DESCRIPTION
- Added link to Token Metadata Service under References. 

![image](https://user-images.githubusercontent.com/55154433/210891621-89687866-f7c6-4d2f-8452-67cfbf78ea06.png)

The Token Metadata service link will be changed with the beta release. @rafaelcr Please update this link. Thanks!
