### PR TITLE
Added Stacks Connect link to references

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -95,7 +95,7 @@ module.exports = {
               },
               {
                 label: 'Stacks Connect',
-                href: 'https://connect.stacks.js.org/modules/_stacks_connect',
+                href: 'https://connect.stacks.js.org',
               },
               {
                 label: 'Clarity Functions',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,6 +94,10 @@ module.exports = {
                 href: 'https://stacks.js.org',
               },
               {
+                label: 'Stacks Connect',
+                href: 'https://connect.stacks.js.org/modules/_stacks_connect',
+              },
+              {
                 label: 'Clarity Functions',
                 href: 'https://docs.stacks.co/docs/write-smart-contracts/clarity-language/language-functions',
               },


### PR DESCRIPTION
Added stacks_connect link to references.

Updated: Docusaurus config file to include the new link under references.

Relates to https://github.com/hirosystems/docs/issues/129