### PR TITLE
Add how-to-use-deployment-plans to the docs left nav

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,7 +167,7 @@ module.exports = {
           documents: ["how-to-add-contract.md", "how-to-check-contract.md", "how-to-create-new-project.md",
           "how-to-debug-contract.md",
           "how-to-deploy-contracts.md", "how-to-deploy-with-subnets.md", "how-to-run-integration-environment.md", "how-to-set-up-local-development-environment.md"
-          ,"how-to-test-contract.md"
+          ,"how-to-test-contract.md","how-to-use-deployment-plans"
             ], 
           
          


### PR DESCRIPTION
## Description
This PR is to add the new how-to-use-deployment plans document to the Clarinet docs left nav. 

1. Motivation for change?
Add new content
2. What was changed?
Docusaurus config file to add a new how-to document.
3. Link to relevant issues?
