### PR TITLE
Fix the deployment-plans

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,7 +162,7 @@ module.exports = {
       {
           
           name: "remote-docs-clarinet-how-to", 
-          sourceBaseUrl: "https://raw.githubusercontent.com/hirosystems/clarinet/develop/docs/how-to-guides/", 
+          sourceBaseUrl: "https://raw.githubusercontent.com/LakshmiLavanyaKasturi/clarinet/image-test/docs/how-to-guides/", 
           outDir: "docs/clarinet/how-to-guides", 
           documents: ["how-to-add-contract.md", "how-to-check-contract.md", "how-to-create-new-project.md",
           "how-to-debug-contract.md",
@@ -201,7 +201,7 @@ module.exports = {
                  "sidebar.png", 
                  "trace.png", 
                  "watchpoint.png", 
-                 "deployment-plan-blocks.png"
+                 "deployment-plans.png"
                 ], 
                 requestConfig: { responseType: "arraybuffer" },
                 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,7 +167,7 @@ module.exports = {
           documents: ["how-to-add-contract.md", "how-to-check-contract.md", "how-to-create-new-project.md",
           "how-to-debug-contract.md",
           "how-to-deploy-contracts.md", "how-to-deploy-with-subnets.md", "how-to-run-integration-environment.md", "how-to-set-up-local-development-environment.md"
-          ,"how-to-test-contract.md"
+          ,"how-to-test-contract.md",  "how-to-use-deployment-plans.md"
             ], 
           
          

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -201,6 +201,7 @@ module.exports = {
                  "sidebar.png", 
                  "trace.png", 
                  "watchpoint.png", 
+                 "deployment-plan-blocks.png"
                 ], 
                 requestConfig: { responseType: "arraybuffer" },
                 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,7 +162,7 @@ module.exports = {
       {
           
           name: "remote-docs-clarinet-how-to", 
-          sourceBaseUrl: "https://raw.githubusercontent.com/LakshmiLavanyaKasturi/clarinet/image-test/docs/how-to-guides/", 
+          sourceBaseUrl: "https://raw.githubusercontent.com/hirosystems/clarinet/develop/docs/how-to-guides/", 
           outDir: "docs/clarinet/how-to-guides", 
           documents: ["how-to-add-contract.md", "how-to-check-contract.md", "how-to-create-new-project.md",
           "how-to-debug-contract.md",

--- a/sidebars.js
+++ b/sidebars.js
@@ -43,6 +43,7 @@ module.exports = {
             'clarinet/how-to-guides/how-to-deploy-contracts',
             'clarinet/how-to-guides/how-to-run-integration-environment',
             'clarinet/how-to-guides/how-to-deploy-with-subnets',
+            'clarinet/how-to-guides/how-to-use-deployment-plans',
           ],
         },
         'clarinet/troubleshooting',


### PR DESCRIPTION
## Description

Describe the changes that were made in this pull request. When possible start with the motivations behind the change. Be sure to also include the following information:

1. Motivation for change? Clarinet how-to-use-deployment-plans missing in prod
2. What was changed? Add the file to the plugin-remote-content-docs and sidebars.js
3. Link to relevant issues? #297 

## Checklist

- [X] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] New links to files and images were verified
- [X] For fixes/refactors: all existing references were identified and replaced
- [X] [Style guide](https://developers.google.com/style) was reviewed and applied
- [X] Clear code samples were provided
- [X] People were tagged for review
