### PR TITLE
revert source-base-url-for stacksjs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ module.exports = {
       'docusaurus-plugin-remote-content',
       {
         name: 'remote-docs-stx-js-docs',
-        sourceBaseUrl: 'https://raw.githubusercontent.com/LakshmiLavanyaKasturi/stacks.js/test-interactive-code/docs/',
+        sourceBaseUrl: 'https://raw.githubusercontent.com/hirosystems/stacks.js/master/docs/',
         outDir: 'docs/stacks.js',
         documents: ['faq.md', 'getting-started.md', 'overview.md', 'troubleshooting.md'],
       },


### PR DESCRIPTION
SourceBaseURL was changed for testing a hackathon project and the changes got merged. So, reverted it back to the docs pointing to the Stacks.js master branch.