### PR TITLE
Added token-metadata-api rate limits

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -164,6 +164,7 @@ module.exports = {
           'https://raw.githubusercontent.com/hirosystems/stacks-subnets/master/docs/images/',
         outDir: 'docs/subnets/images',
         documents: [
+          'deposit-stx.png',
           'subnet-devnet.png',
           'subnet-miners.png',
           'subnets-architecture.png',
@@ -198,6 +199,16 @@ module.exports = {
           'how-to-use-chainhook-with-bitcoin.md',
           'how-to-use-chainhook-with-stacks.md',
         ],
+      },
+    ],
+    [
+      'docusaurus-plugin-remote-content',
+      {
+        name: 'remote-docs-ordinals-feature-guides',
+        sourceBaseUrl:
+          'https://raw.githubusercontent.com/hirosystems/ordinals-api/master/docs/feature-guides/',
+        outDir: 'docs/ordinals-api/feature-guides',
+        documents: ['rate-limiting.md'],
       },
     ],
     [
@@ -311,7 +322,7 @@ module.exports = {
         sourceBaseUrl:
           'https://raw.githubusercontent.com/hirosystems/token-metadata-api/master/docs/feature-guides/',
         outDir: 'docs/token-metadata-api/feature-guides',
-        documents: ['token-metadata-api.md'],
+        documents: ['token-metadata-api.md', 'rate-limiting.md'],
       },
     ],
     [

--- a/sidebars.js
+++ b/sidebars.js
@@ -170,7 +170,41 @@ module.exports = {
         'platform/contract-examples',
         'platform/faq',
       ],
-    }, 
+    },
+    {
+      type: 'category',
+      label: 'Ordinals API',
+      items: [
+        {
+          type: 'category',
+          label: 'Feature Guides',
+          items: [
+            'ordinals-api/feature-guides/rate-limiting',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Developer Resources',
+          items: [
+            {
+              type: 'link',
+              label: 'Discord #ordinals',
+              href: 'https://discord.com/channels/621759717756370964/1101164749984649256',
+            },
+            {
+              type: 'link',
+              label: 'Blogs',
+              href: 'https://www.hiro.so/search?query=Ordinals',
+            },
+            {
+              type: 'link',
+              label: 'Videos',
+              href: 'https://www.youtube.com/watch?v=p1clYRMkaFI',
+            },
+          ],
+        },
+      ],
+    },
     {
       type: 'category',
       label: 'Stacks Blockchain API',
@@ -353,6 +387,7 @@ module.exports = {
           label: 'Feature Guides',
           items: [
             'token-metadata-api/feature-guides/token-metadata-api',
+            'token-metadata-api/feature-guides/rate-limiting'
           ],
         },
       ],


### PR DESCRIPTION
- Added Ordinals-API to the left nav. 
- Updated docusaurus config to use rate-limit docs from both Ordinals API and Token-metadata API repos.
- Added subnets - missing image entry to the docusaurus config file.