### PR TITLE
fix: clarity_version field in stacks 2.1 upgrade guide

### DIFF
--- a/docs/stacks-2.1-upgrades.md
+++ b/docs/stacks-2.1-upgrades.md
@@ -47,7 +47,7 @@ In your project's `Clarinet.toml` file, you can now specify the epoch during whi
 ```toml
 [contracts.cbtc-token]
 path = "contracts/cbtc-token.clar"
-clarity = 2
+clarity_version = 2
 epoch = "2.1"
 ```
 


### PR DESCRIPTION
## Description

Fix manifest property name `clarity_version`
