### PR TITLE
chore: switch to hiro.so where appropriate.

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -13,7 +13,7 @@
       "pattern": "(gaia|hub).blockstack.org"
     },
     {
-      "pattern": "explorer.stacks.co/txid"
+      "pattern": "explorer.hiro.so/txid"
     },
     {
       "pattern": "explorer-api.legacy.blockstack.org"

--- a/docs/build-apps/integrate-stacking-delegation.md
+++ b/docs/build-apps/integrate-stacking-delegation.md
@@ -35,7 +35,7 @@ stacks make_keychain -t > delegator.json
 You can use the faucet to obtain testnet STX tokens for the test account. Replace `<stxAddress>` below with your address:
 
 ```sh
-curl -XPOST "https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
+curl -XPOST "https://api.testnet.hiro.so/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
 ```
 
 ## Step 1: Integrate libraries

--- a/docs/build-apps/integrate-stacking.md
+++ b/docs/build-apps/integrate-stacking.md
@@ -166,7 +166,7 @@ const hasMinStxAmount = await client.hasMinimumStx();
 For testing purposes, you can use the faucet to obtain testnet STX tokens. Replace `<stxAddress>` below with your address:
 
 ```shell
-curl -XPOST "https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
+curl -XPOST "https://api.testnet.hiro.so/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
 ```
 
 You'll have to wait a few minutes for the transaction to complete.
@@ -347,5 +347,5 @@ As an example, if you want to get the rewards paid to `btcAddress`, you can make
 
 ```shell
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/burnchain/rewards/<btcAddress>'
+curl 'https://api.testnet.hiro.so/extended/v1/burnchain/rewards/<btcAddress>'
 ```

--- a/docs/build-apps/transaction-signing.md
+++ b/docs/build-apps/transaction-signing.md
@@ -274,7 +274,7 @@ The `txId` property can be used to provide a link to view the transaction in the
 
 ```ts
 const onFinish = data => {
-  const explorerTransactionUrl = 'https://explorer.stacks.co/txid/${data.txId}';
+  const explorerTransactionUrl = 'https://explorer.hiro.so/txid/${data.txId}';
   console.log('View transaction in explorer:', explorerTransactionUrl);
 };
 ```
@@ -332,7 +332,7 @@ const MyComponent = () => {
 
 ## Request testnet STX from faucet
 
-You may find it useful to request testnet STX from [the Explorer sandbox](https://explorer.stacks.co/sandbox/deploy?chain=testnet) while developing your app with the Stacks testnet.
+You may find it useful to request testnet STX from [the Explorer sandbox](https://explorer.hiro.so/sandbox/deploy?chain=testnet) while developing your app with the Stacks testnet.
 
 ## Transaction request / response payload
 

--- a/docs/example-apps/public-registry.md
+++ b/docs/example-apps/public-registry.md
@@ -28,7 +28,7 @@ and confirm that all systems are operational. If some systems seem to have issue
 
 Furthermore, the to-dos app will interact with a smart contract deployed as `ST1234....todo-registry`. The contract source code is available at [GitHub](https://github.com/friedger/blockstack-todos/blob/tut/step1/contracts/todo-registry.clar).
 
-There may already be a deployed version available on the testnet; the [Explorer](https://explorer.stacks.co/) can be used to search for it.
+There may already be a deployed version available on the testnet; the [Explorer](https://explorer.hiro.so/) can be used to search for it.
 
 Alternatively, the contract can be deployed as described in the [hello world tutorial](/tutorials/clarity-hello-world). Then you have to use the corresponding contract address and name in this tutorial. Throughout this tutorial, we use `ST3YPJ6BBCZCMH71TV8BK50YC6QJTWEGCNDFWEQ15.todo-registry` as an example.
 

--- a/docs/get-started/command-line-interface.md
+++ b/docs/get-started/command-line-interface.md
@@ -101,7 +101,7 @@ The response should look like this:
 
 :::tip
 
-To receive testnet STX tokens, use the [faucet](https://explorer.stacks.co/sandbox/faucet?chain=testnet).
+To receive testnet STX tokens, use the [faucet](https://explorer.hiro.so/sandbox/faucet?chain=testnet).
 
 :::
 
@@ -130,7 +130,7 @@ stx send_tokens ST2KMMVJAB00W5Z6XWTFPH6B13JE9RJ2DCSHYX0S7 1000 200 0 381314da39a
 ```json
 {
   "txid": "0xd32de0d66b4a07e0d7eeca320c37a10111c8c703315e79e17df76de6950c622c",
-  "transaction": "https://explorer.stacks.co/txid/0xd32de0d66b4a07e0d7eeca320c37a10111c8c703315e79e17df76de6950c622c"
+  "transaction": "https://explorer.hiro.so/txid/0xd32de0d66b4a07e0d7eeca320c37a10111c8c703315e79e17df76de6950c622c"
 }
 ```
 

--- a/docs/get-started/stacks-blockchain-api.md
+++ b/docs/get-started/stacks-blockchain-api.md
@@ -15,7 +15,7 @@ The RESTful JSON API can be used without any authorization. The base path for th
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
-https://stacks-node-api.testnet.stacks.co/
+https://api.testnet.hiro.so/
 ```
 
 :::info
@@ -79,7 +79,7 @@ import { Configuration, AccountsApi } from '@stacks/blockchain-api-client';
   const apiConfig = new Configuration({
     fetchApi: fetch,
     // for mainnet, replace `testnet` with `mainnet`
-    basePath: 'https://stacks-node-api.testnet.stacks.co', // defaults to http://localhost:3999
+    basePath: 'https://api.testnet.hiro.so', // defaults to http://localhost:3999
   });
 
   // initiate the /accounts API with the basepath and fetch library
@@ -112,7 +112,7 @@ import {
   const apiConfig: Configuration = new Configuration({
     fetchApi: fetch,
     // for mainnet, replace `testnet` with `mainnet`
-    basePath: 'https://stacks-node-api.testnet.stacks.co', // defaults to http://localhost:3999
+    basePath: 'https://api.testnet.hiro.so', // defaults to http://localhost:3999
   });
 
   const principal: string = 'ST000000000000000000002AMW42H';
@@ -156,12 +156,12 @@ You can refer to the rate limit for each endpoint in the table below:
 
 | **Endpoint**                                                                                | **Rate-Limit (RPM)**  |
 | ------------------------------------------------------------------------------------------- | --------------------- |
-| stacks-node-api.mainnet.stacks.co/extended/ <br/> stacks-node-api.stacks.co/extended/ <br/> | <br/> 500 <br/> <br/> |
-| stacks-node-api.mainnet.stacks.co/rosetta/ <br/> stacks-node-api.stacks.co/rosetta/<br/>    | <br/> 200 <br/> <br/> |
-| stacks-node-api.mainnet.stacks.co/v2/ <br/> stacks-node-api.stacks.co/v2/ <br/>             | <br/> 100 <br/> <br/> |
-| stacks-node-api.testnet.stacks.co/extended/ <br/>                                           | 100 <br/>             |
-| stacks-node-api.testnet.stacks.co/v2/ <br/>                                                 | 100 <br/>             |
-| stacks-node-api.testnet.stacks.co/extended/v1/faucets/ <br/>                                | 1 <br/>               |
+| api.mainnet.hiro.so/extended/ <br/> stacks-node-api.stacks.co/extended/ <br/> | <br/> 500 <br/> <br/> |
+| api.mainnet.hiro.so/rosetta/ <br/> stacks-node-api.stacks.co/rosetta/<br/>    | <br/> 200 <br/> <br/> |
+| api.mainnet.hiro.so/v2/ <br/> stacks-node-api.stacks.co/v2/ <br/>             | <br/> 100 <br/> <br/> |
+| api.testnet.hiro.so/extended/ <br/>                                           | 100 <br/>             |
+| api.testnet.hiro.so/v2/ <br/>                                                 | 100 <br/>             |
+| api.testnet.hiro.so/extended/v1/faucets/ <br/>                                | 1 <br/>               |
 
 ### STX faucet
 
@@ -255,7 +255,7 @@ import { uintCV, UIntCV, cvToHex, hexToCV, ClarityType } from '@stacks/transacti
   const apiConfig: Configuration = new Configuration({
     fetchApi: fetch,
     // for mainnet, replace `testnet` with `mainnet`
-    basePath: 'https://stacks-node-api.testnet.stacks.co', // defaults to http://localhost:3999
+    basePath: 'https://api.testnet.hiro.so', // defaults to http://localhost:3999
   });
 
   const contractsApi: SmartContractsApiInterface = new SmartContractsApi(apiConfig);

--- a/docs/get-started/transactions.md
+++ b/docs/get-started/transactions.md
@@ -422,7 +422,7 @@ With a serialized transaction in the [raw format](#raw-format), it can be broadc
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
-curl --location --request POST 'https://stacks-node-api.testnet.stacks.co/v2/transactions' \
+curl --location --request POST 'https://api.testnet.hiro.so/v2/transactions' \
 --header 'Content-Type: application/octet-stream' \
 --data-raw '<tx_raw_format>'
 ```
@@ -440,7 +440,7 @@ Once a transaction has been successfully broadcast to the network, the transacti
 that received the broadcast. From the [Bitcoin wiki][]: "a node's memory pool contains all 0-confirmation transactions
 across the entire network that that particular node knows about." So, the set of transactions in the mempool might be
 different for each node in the network. For example, when you query the mempool endpoints on
-`stacks-node-api.mainnet.stacks.co`, the response reflects the set of unconfirmed transactions known to the nodes that
+`api.mainnet.hiro.so`, the response reflects the set of unconfirmed transactions known to the nodes that
 service that API.
 
 Miners can employ different heuristics and strategies for deciding which transactions to admit into the mempool and
@@ -482,7 +482,7 @@ Recent transactions can be obtained through the [`GET /extended/v1/tx`](https://
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/tx'
+curl 'https://api.testnet.hiro.so/extended/v1/tx'
 ```
 
 Sample response:
@@ -520,7 +520,7 @@ Mempool (registered, but not processed) transactions can be obtained using the [
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/tx/mempool'
+curl 'https://api.testnet.hiro.so/extended/v1/tx/mempool'
 ```
 
 Sample response:
@@ -559,7 +559,7 @@ Recent transactions can be filtered by [transaction type](#types) using the `typ
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/tx/?type=contract_call'
+curl 'https://api.testnet.hiro.so/extended/v1/tx/?type=contract_call'
 ```
 
 ### Get transaction by ID
@@ -568,7 +568,7 @@ A specific transaction can be obtained using the [`GET /extended/v1/tx/<tx_id>`]
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/tx/<tx_id>'
+curl 'https://api.testnet.hiro.so/extended/v1/tx/<tx_id>'
 ```
 
 Sample response:

--- a/docs/platform/deploy-project.md
+++ b/docs/platform/deploy-project.md
@@ -35,11 +35,11 @@ The following are the steps to deploy your contracts using the **Deploy** button
 
 ## Monitor your contract in Explorer
 
-This section helps you with the steps to monitor your contract in the [Explorer](https://explorer.stacks.co/?chain=mainnet).
+This section helps you with the steps to monitor your contract in the [Explorer](https://explorer.hiro.so/?chain=mainnet).
 
 1. You can now use the Pop-out button *View explorer* beside the *deployed* status to monitor your contract in Explorer.
 ![Exporer view](images/explorer-view.png)
-2. The  *view explorer* button opens up [Explorer](https://explorer.stacks.co/?chain=mainnet) to view the contract you just deployed in the mainnet/testnet environments.
+2. The  *view explorer* button opens up [Explorer](https://explorer.hiro.so/?chain=mainnet) to view the contract you just deployed in the mainnet/testnet environments.
 ![Explorer](images/explorer.jpeg) 
 3. You can check the summary of your contracts, contract details, etc., in Explorer.
 

--- a/docs/stacks-2.1-upgrades.md
+++ b/docs/stacks-2.1-upgrades.md
@@ -12,7 +12,7 @@ In this article, you will learn about Stacks 2.05 to 2.1 migration and how the H
 
 ## What is PoX-2?
 
-[Proof-of-transfer (PoX)](https://docs.stacks.co/docs/understand-stacks/proof-of-transfer) is a consensus mechanism in modern blockchains. In Stacks 2.05 or earlier versions, this consensus mechanism uses the `.pox` ([boot/pox.clar](https://explorer.stacks.co/txid/SP000000000000000000002Q6VF78.pox?chain=mainnet&_gl=1*6fljeg*_ga*MTY3NTgyOTg2OS4xNjY2MjA3NDM3*_ga_NB2VBT0KY2*MTY3MDk1ODcyNS4xMTEuMC4xNjcwOTU4NzI1LjAuMC4w), aka PoX-1) boot smart contract. With the Stacks 2.1 upgrade, the new fork is updated to `.pox-2` ([boot/pox-2.clar](https://github.com/stacks-network/stacks-blockchain/blob/next/src/chainstate/stacks/boot/pox-2.clar), aka PoX-2).
+[Proof-of-transfer (PoX)](https://docs.stacks.co/docs/understand-stacks/proof-of-transfer) is a consensus mechanism in modern blockchains. In Stacks 2.05 or earlier versions, this consensus mechanism uses the `.pox` ([boot/pox.clar](https://explorer.hiro.so/txid/SP000000000000000000002Q6VF78.pox?chain=mainnet&_gl=1*6fljeg*_ga*MTY3NTgyOTg2OS4xNjY2MjA3NDM3*_ga_NB2VBT0KY2*MTY3MDk1ODcyNS4xMTEuMC4xNjcwOTU4NzI1LjAuMC4w), aka PoX-1) boot smart contract. With the Stacks 2.1 upgrade, the new fork is updated to `.pox-2` ([boot/pox-2.clar](https://github.com/stacks-network/stacks-blockchain/blob/next/src/chainstate/stacks/boot/pox-2.clar), aka PoX-2).
 
 ### PoX-2 periods
 

--- a/docs/tutorials/clarity-counter.md
+++ b/docs/tutorials/clarity-counter.md
@@ -245,9 +245,9 @@ the strengths of performing local development without having to wait for block t
 [clarinet]: /smart-contracts/clarinet
 [installing clarinet]: /smart-contracts/clarinet#installing-clarinet
 [`define-data-var`]: https://docs.stacks.co/references/language-functions#define-data-var
-[testnet sandbox]: https://explorer.stacks.co/sandbox/deploy?chain=testnet
+[testnet sandbox]: https://explorer.hiro.so/sandbox/deploy?chain=testnet
 [stacks web wallet]: https://www.hiro.so/wallet/install-web
-[testnet faucet]: https://explorer.stacks.co/sandbox/faucet?chain=testnet
+[testnet faucet]: https://explorer.hiro.so/sandbox/faucet?chain=testnet
 [unit tests]: /smart-contracts/clarinet#testing-with-clarinet
 [`var-get`]: https://docs.stacks.co/references/language-functions#var-get
 [`clarinet console`]: /smart-contracts/clarinet#testing-with-the-console
@@ -255,6 +255,6 @@ the strengths of performing local development without having to wait for block t
 [`var-set`]: https://docs.stacks.co/references/language-functions#var-set
 [`+`]: https://docs.stacks.co/references/language-functions#-add
 [clarity language reference]: https://docs.stacks.co/references/language-functions
-[transactions]: https://explorer.stacks.co/transactions?chain=testnet
+[transactions]: https://explorer.hiro.so/transactions?chain=testnet
 [clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp
-[call a contract]: https://explorer.stacks.co/sandbox/contract-call?chain=testnet
+[call a contract]: https://explorer.hiro.so/sandbox/contract-call?chain=testnet

--- a/docs/tutorials/clarity-hello-world.md
+++ b/docs/tutorials/clarity-hello-world.md
@@ -255,14 +255,14 @@ the strengths of performing local development without having to wait for block t
 [clarinet]: /smart-contracts/clarinet
 [installing clarinet]: /smart-contracts/clarinet#installing-clarinet
 [clarity.tools]: https://clarity.tools
-[testnet sandbox]: https://explorer.stacks.co/sandbox/deploy?chain=testnet
+[testnet sandbox]: https://explorer.hiro.so/sandbox/deploy?chain=testnet
 [stacks web wallet]: https://www.hiro.so/wallet/install-web
-[testnet faucet]: https://explorer.stacks.co/sandbox/faucet?chain=testnet
+[testnet faucet]: https://explorer.hiro.so/sandbox/faucet?chain=testnet
 [step 3]: #step-3-add-code-to-the-hello-world-contract
 [unit tests]: /smart-contracts/clarinet#testing-with-clarinet
 [separating concerns]: https://en.wikipedia.org/wiki/Separation_of_concerns
 [`ok`]: https://docs.stacks.co/references/language-functions#ok
 [read-only function]: https://docs.stacks.co/references/language-functions#define-read-only
-[transactions]: https://explorer.stacks.co/transactions?chain=testnet
-[call a contract]: https://explorer.stacks.co/sandbox/contract-call?chain=testnet
+[transactions]: https://explorer.hiro.so/transactions?chain=testnet
+[call a contract]: https://explorer.hiro.so/sandbox/contract-call?chain=testnet
 [clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp

--- a/docs/tutorials/clarity-nft.md
+++ b/docs/tutorials/clarity-nft.md
@@ -34,9 +34,9 @@ If you are using Visual Studio Code, you may want to install the [Clarity Visual
 ### Optional prerequisites
 
 While this tutorial primarily focuses on local smart contract development, you may wish to deploy your contract to a
-live blockchain. For simplicity, contract deployment is performed using the [testnet sandbox](https://explorer.stacks.co/sandbox/deploy?chain=testnet).
+live blockchain. For simplicity, contract deployment is performed using the [testnet sandbox](https://explorer.hiro.so/sandbox/deploy?chain=testnet).
 If you wish to complete the optional deployment step, you should have the [Stacks Web Wallet](https://www.hiro.so/wallet/install-web)
-installed, and you should request testnet STX tokens from the [testnet faucet](https://explorer.stacks.co/sandbox/faucet?chain=testnet)
+installed, and you should request testnet STX tokens from the [testnet faucet](https://explorer.hiro.so/sandbox/faucet?chain=testnet)
 on the testnet explorer. Note that requesting testnet STX from the faucet can take up to 15 minuets, so you may wish to
 request the tokens before beginning the tutorial.
 
@@ -275,21 +275,21 @@ like to try deploying your contract to the testnet, proceed with the following o
 
 ## Optional: Deploy the NFT to the testnet
 
-For this tutorial, you'll use the [testnet sandbox](https://explorer.stacks.co/sandbox/deploy?chain=testnet) to deploy
+For this tutorial, you'll use the [testnet sandbox](https://explorer.hiro.so/sandbox/deploy?chain=testnet) to deploy
 your smart contract. Make sure you have connected your [Stacks web wallet](https://www.hiro.so/wallet/install-web) to
 the sandbox using the **Connect wallet** button, then copy and paste the `my-nft.clar` smart contract into the Clarity
-code editor on the [Write & Deploy](https://explorer.stacks.co/sandbox/deploy?chain=testnet) page. Edit the contract name or use the randomly generated name provided to you.
+code editor on the [Write & Deploy](https://explorer.hiro.so/sandbox/deploy?chain=testnet) page. Edit the contract name or use the randomly generated name provided to you.
 
 Click **Deploy** to deploy the contract to the blockchain. This will display the Stacks web wallet window with
 information about the transaction. Verify that the transaction looks correct, and the network is set to `Testnet`, and
 click **Confirm**.
 
 The deployment process can take up to 15 minutes to complete. You can review it on the
-[transactions](https://explorer.stacks.co/transactions?chain=testnet) page of the explorer, or in the activity field of
+[transactions](https://explorer.hiro.so/transactions?chain=testnet) page of the explorer, or in the activity field of
 your web wallet.
 
 When your contract is confirmed, navigate to the
-[Call a contract](https://explorer.stacks.co/sandbox/contract-call?chain=testnet) page of the sandbox, and search for
+[Call a contract](https://explorer.hiro.so/sandbox/contract-call?chain=testnet) page of the sandbox, and search for
 your contract. Enter your wallet address in the top field, can you copy this address by clicking the Stacks web wallet
 icon and clicking the **Copy address** button. Enter the contract name in the bottom field, in this case `my-nft`. Click
 **Get contract** to view the contract.

--- a/docs/tutorials/managing-accounts.md
+++ b/docs/tutorials/managing-accounts.md
@@ -61,7 +61,7 @@ const {
 const apiConfig = new Configuration({
   fetchApi: fetch,
   // for mainnet, replace `testnet` with `mainnet`
-  basePath: "https://stacks-node-api.testnet.stacks.co",
+  basePath: "https://api.testnet.hiro.so",
 });
 
 const privateKey = makeRandomPrivKey();
@@ -156,7 +156,7 @@ The API will respond with a new transaction ID and confirmation that the faucet 
 
 :::note
 
-Wait a few minutes for the transaction to complete. You can review the status using the Explorer, by navigating to the following URL: `https://explorer.stacks.co/txid/<txid>`.
+Wait a few minutes for the transaction to complete. You can review the status using the Explorer, by navigating to the following URL: `https://explorer.hiro.so/txid/<txid>`.
 
 :::
 

--- a/docs/tutorials/sending-tokens.md
+++ b/docs/tutorials/sending-tokens.md
@@ -66,7 +66,7 @@ const { TransactionsApi, Configuration } = require('@stacks/blockchain-api-clien
 const apiConfig = new Configuration({
   fetchApi: fetch,
   // for mainnet, replace `testnet` with `mainnet`
-  basePath: 'https://stacks-node-api.testnet.stacks.co',
+  basePath: 'https://api.testnet.hiro.so',
 });
 
 const key = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc01';

--- a/docs/tutorials/stacking-using-cli.md
+++ b/docs/tutorials/stacking-using-cli.md
@@ -56,7 +56,7 @@ Use the following `curl` command to request tokens from the testnet node's fauce
 We use the address generated above as a parameter.
 
 ```bash
-curl -X POST https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=ST1P3HXR80TKT48TKM2VTKCDBS4ET9396W0W2S3K8&stacking=true
+curl -X POST https://api.testnet.hiro.so/extended/v1/faucets/stx?address=ST1P3HXR80TKT48TKM2VTKCDBS4ET9396W0W2S3K8&stacking=true
 ```
 
 ## Check Balance
@@ -115,7 +115,7 @@ stx stack 90000000000000 10 mqkccNX5h7Xy1YUku3X2fCFCC54x6HEiHk dca82f838f6e5a893
 
 {
   txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
-  transaction: 'https://explorer.stacks.co/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+  transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
 }
 ```
 


### PR DESCRIPTION
## Description

Update domain from `stacks.co` to `hiro.so` where appropriate: specifically, for API and 
Stacks Explorer references.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] People were tagged for review
