### PR TITLE
Docs: Removed $ from the CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
 # Hiro developer documentation
 
-This repository holds source for the Hiro developer documentation website, which is deployed at [docs.hiro.so](https://docs.hiro.so). This website is built using [Docusaurus](https://docusaurus.io/).
+This repository holds the source for the Hiro developer documentation website, which is deployed at [docs.hiro.so](https://docs.hiro.so). This website is built using [Docusaurus](https://docusaurus.io/).
 
 ## Installation
 
 Use the following command to install local build and development dependencies.
 
-```
-$ yarn
-```
+`yarn`
 
 ## Local Development
 
 The following command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server. Make sure that you have [installed dependencies](#installation) before doing local development.
 
-```
-$ yarn start
-```
+`yarn start`
 
 ## Build
 
 The following command will build the final static website into the `build` directory.
 
-```
-$ yarn build
-```
+`yarn build`
 
 ### Deployment
 

--- a/docs/stacks-2.1-upgrades.md
+++ b/docs/stacks-2.1-upgrades.md
@@ -84,7 +84,7 @@ disable_stacks_api = false
 
 Spin up a local Devnet network using the command:
 
-`$ clarinet integrate`
+`clarinet integrate`
 
 If you have any trouble with the above command, refer to the [troubleshooting guide](https://github.com/hirosystems/clarinet/blob/main/docs/troubleshooting.md) or report an issue [here](https://github.com/hirosystems/clarinet/issues).
 


### PR DESCRIPTION
Removed `$` from the CLI commands.
Fixes https://github.com/hirosystems/docs/issues/409