### PR TITLE
Edit typo in Hiro Platform/Getting Started

### DIFF
--- a/docs/platform/getting-started.md
+++ b/docs/platform/getting-started.md
@@ -56,6 +56,6 @@ Once your Clarity contracts are ready to deploy, follow the [deploy project](dep
 
 To monitor the progress of your deployed contract, you can use the links to Explorer assigned to each contract and verify the submitted deployment transaction.
 
-![explorer view](images/explorer-view.png){widtch}
+![explorer view](images/explorer-view.png)
 
 ![explorer](images/explorer.jpeg)


### PR DESCRIPTION
## Description

Fixed a typo in the Getting Started page of Hiro Platform section.