### PR TITLE
Updated tip for clarity programming in the Platform-Build contract

### DIFF
--- a/docs/platform/build-contract.md
+++ b/docs/platform/build-contract.md
@@ -13,7 +13,7 @@ This article helps you create/build contracts using the [Hiro Platform](https://
 
 :::tip
 
-If you are new to Clarity programming, please try [Clarity Camp](https://learn.stacks.org/course/clarity-camp).
+If you are new to Clarity programming, please try the [Bitcoin Builders Primer](https://start.bitcoinprimer.dev/).
 
 :::
 


### PR DESCRIPTION
 - Updated Tip to use [Bitcoin Builders Primer](https://start.bitcoinprimer.dev/) for Clarity programming.
 Fixes https://github.com/hirosystems/docs/issues/432