### PR TITLE
Add Alltius widget for interactive Q+A engagement

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,6 +18,7 @@ module.exports = {
   plugins: [
     require.resolve('docusaurus-plugin-segment'),
     ['./src/_plugins/google-tag-manager', { id: 'GTM-59XXGSG' }],
+    ['./src/_plugins/alltius', { id: 'alltius' }],
     [
       'docusaurus-plugin-openapi',
       {

--- a/src/_plugins/alltius/index.js
+++ b/src/_plugins/alltius/index.js
@@ -1,0 +1,28 @@
+module.exports = async function alltiusPlugin(_context, options) {
+  return {
+    name: 'gtm-plugin',
+    injectHtmlTags() {
+      return {
+        headTags: [
+`<!-- Start Alltius Config -->
+<script> (() => {const p=(l,s,a,i)=>{const n=()=>{if(!s.getElementById(a)){const e=s.getElementsByTagName(i)[0],t=s.createElement(i);t.type="text/javascript",t.async=!1,t.src="https://app.alltius.ai/alltiusSDK.js",t.id=a,e&&e.parentNode?e.parentNode.insertBefore(t,e):s.body.appendChild(t)}};if(!l.AlltiusSDK){const e=(...t)=>{e.q.push(t)};e.q=[],l.AlltiusSDK=e,s.readyState==="complete"?n():l.addEventListener("load",n)}};p(window,document,"alltius-sdk","script");})()
+window.AlltiusSDK = {
+  q: [
+    [
+      'configure',
+      {
+        metatadata: {
+          widgetId: '64ef58020ada4eb2fb38ea9b',
+        },
+      },
+    ],
+  ],
+}; </script>
+<!-- End Alltius Config -->`,
+        ],
+        postBodyTags: [
+        ],
+      };
+    },
+  };
+};

--- a/src/_plugins/alltius/index.js
+++ b/src/_plugins/alltius/index.js
@@ -1,6 +1,6 @@
 module.exports = async function alltiusPlugin(_context, options) {
   return {
-    name: 'gtm-plugin',
+    name: 'alltius-plugin',
     injectHtmlTags() {
       return {
         headTags: [


### PR DESCRIPTION
This proposal adds the Alltius widget to support LLM-based user interaction with the Docs site and its content. Here's an example interaction:

![image](https://github.com/hirosystems/docs/assets/1562654/a7dcfc72-9c86-4514-a6ae-777a5823acc6)

Additionally, the backing training dataset periodically crawls through Docs site content, Hiro's website/assets, Hiro's blogs, and Hiro's YT playlist.

Until we get the UI/UX to match Hiro's thematic brand, which is a WIP on the Alltius end (awaiting their deliverable), we will not merge the PR yet. So aside from the UIUX, any alterations to plugin and script integration is welcome. 