### PR TITLE
chore: remove Node 19 constraint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "^0.11.1"
   },
   "engines": {
-    "node": ">=16 <19"
+    "node": ">=16"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Seems to work fine with Node 20+ with this change.

## Description

Without this, `yarn` would fail with:
```
yarn install v1.22.19
[1/5] 🔍  Validating package.json...
error @hirosystems/docs@0.1.0: The engine "node" is incompatible with this module. Expected version ">=16 <19". Go
t "20.7.0"
error Found incompatible module.
```

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
