### PR TITLE
Use Markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,25 @@ This repository holds the source for the Hiro developer documentation website, w
 
 Use the following command to install local build and development dependencies.
 
-`yarn`
+```sh
+yarn
+```
 
 ## Local Development
 
 The following command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server. Make sure that you have [installed dependencies](#installation) before doing local development.
 
-`yarn start`
+```sh
+yarn start
+```
 
 ## Build
 
 The following command will build the final static website into the `build` directory.
 
-`yarn build`
+```sh
+yarn build
+```
 
 ### Deployment
 

--- a/docs/contributors-guide.md
+++ b/docs/contributors-guide.md
@@ -29,18 +29,20 @@ For larger edits or new documents, edit the docs locally, following the steps d
 To submit a pull request to update the docs, fork the Hiro Docs repository and then clone it. Currently all Hiro docs are located in `/hirosystems/docs`
 
 1. Create a branch and switch to that branch:
-    
-    `git checkout -b <branch-name>`
-    
+    ```sh
+    git checkout -b <branch-name>
+    ```
+
 2. Add or modify the GitHub Markdown files in the directories.
 3. When the suggested changes are complete, commit them with a message with a brief summary message:
-    
-    `git commit -m "commit message"`
-    
+    ```sh
+    git commit -m "commit message"
+    ```
+
 4. Push the branch up:
-    
-    `git push origin <branch-name>`
-    
+    ```sh
+    git push origin <branch-name>
+    ```
 
 When the changes are final, create a pull request from the working branch by following [GitHub's guide](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 

--- a/docs/how-to-use-api-key.md
+++ b/docs/how-to-use-api-key.md
@@ -22,7 +22,9 @@ There are multiple ways to interact with the API endpoints. In this guide, we wi
 
 Using cURL, you will pass the API key in an `x-hiro-api-key` header. Use the following command as an example to call the API endpoint `https://api.hiro.so/<your-api-endpoint>`.
 
-`curl https://api.hiro.so/... -H 'x-hiro-api-key: <your-API-value>'`
+```sh
+curl https://api.hiro.so/... -H 'x-hiro-api-key: <your-API-value>'
+```
 
 ## Using the API key in Typescript
 

--- a/docs/platform/build-contract.md
+++ b/docs/platform/build-contract.md
@@ -40,15 +40,16 @@ You can create a new contract for your project by following the steps below. Not
 7. This will create a `.clar` file in the *contracts* folder. Now you can use the [clarity examples](https://github.com/hirosystems/clarity-examples) to customize your contract.
 8. Once you are ready with your `.clar` file, you can update the `Clarinet.toml` file located in the same project directory. Use the following code to update the `.toml` file with these parameters. `[contracts.<your-contract-name>]` and path to use your `.clar` file name as `path = "<your-contract-name.clar>"`.
 
-    ```
-    [project]
-    name = "CLARITY-EXAMPLES-5XE7"
-    requirements = []
-    [contracts.clarity_contract_1]
-    path = "clarity_contract_1.clar"
-    clarity_version = 1
-    epoch = "2.05"
-    ```
+```toml
+[project]
+name = "CLARITY-EXAMPLES-5XE7"
+requirements = []
+[contracts.clarity_contract_1]
+path = "clarity_contract_1.clar"
+clarity_version = 1
+epoch = "2.05"
+```
+
 Save the file. You can now deploy your contracts in your project by referring to the [deploy project](deploy-project.md) guide.
 
 ## Add a new contract
@@ -59,17 +60,17 @@ You can now add a new contract by following **1-7** steps in the [write new cont
 
 In the 8th step, where you edit the `Clarinet.toml` file, you will add two lines of code, as shown below. Note that the below code assumes that the newly added contract is *clarity_contract_2*. Also, add the path to your new contract as shown below.
 
-    ```
-    [project]
-    name = "CLARITY-EXAMPLES-5XE7"
-    requirements = []
-    [contracts.clarity_contract_1.clar]
-    [contracts.clarity_contract_2.clar]  --> new
-    path = "clarity_contract_1.clar"
-    path = "clarity_contract_2.clar"  --> new
-    clarity_version = 1
-    epoch = "2.05"
-    ```
+```toml
+[project]
+name = "CLARITY-EXAMPLES-5XE7"
+requirements = []
+[contracts.clarity_contract_1.clar]
+[contracts.clarity_contract_2.clar]  # --> new
+path = "clarity_contract_1.clar"
+path = "clarity_contract_2.clar" # --> new
+clarity_version = 1
+epoch = "2.05"
+```
 
 ### Test contract
 

--- a/docs/references/_commands.md
+++ b/docs/references/_commands.md
@@ -10,16 +10,16 @@ If this command succeeds, it will print a transaction ID.  The rest of the Block
 
 Examples:
 
-    $ # Tip: You can obtain the owner key with the get_owner_keys command
-    $ export OWNER_KEY="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
-    $ stx announce 737c631c7c5d911c6617993c21fba731363f1cfe "$OWNER_KEY"
-    d51749aeec2803e91a2f8bdec8d3e413491fd816b4962372b214ab74acb0bba8
+```console
+$ # Tip: You can obtain the owner key with the get_owner_keys command
+$ export OWNER_KEY="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
+$ stx announce 737c631c7c5d911c6617993c21fba731363f1cfe "$OWNER_KEY"
+d51749aeec2803e91a2f8bdec8d3e413491fd816b4962372b214ab74acb0bba8
 
-    $ export OWNER_KEY="2,136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01,1885cba486a42960499d1f137ef3a475725ceb11f45d74631f9928280196f67401,2418981c7f3a91d4467a65a518e14fafa30e07e6879c11fab7106ea72b49a7cb01"
-    $ stx announce 737c631c7c5d911c6617993c21fba731363f1cfe "$OWNER_KEY"
-    8136a1114098893b28a693e8d84451abf99ee37ef8766f4bc59808eed76968c9
-
-
+$ export OWNER_KEY="2,136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01,1885cba486a42960499d1f137ef3a475725ceb11f45d74631f9928280196f67401,2418981c7f3a91d4467a65a518e14fafa30e07e6879c11fab7106ea72b49a7cb01"
+$ stx announce 737c631c7c5d911c6617993c21fba731363f1cfe "$OWNER_KEY"
+8136a1114098893b28a693e8d84451abf99ee37ef8766f4bc59808eed76968c9
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -36,13 +36,14 @@ You can supply your encrypted backup phrase instead of the raw backup phrase.  I
 
 Example:
 
-    $ export BACKUP_PHRASE="oak indicate inside poet please share dinner monitor glow hire source perfect"
-    $ export APP_GAIA_HUB="https://1.2.3.4"
-    $ export PROFILE_GAIA_HUB="https://hub.blockstack.org"
-    $ stx authenticator "$APP_GAIA_HUB" "$BACKUP_PHRASE" "$PROFILE_GAIA_HUB" 8888
-    Press Ctrl+C to exit
-    Authentication server started on 8888
-
+```console
+$ export BACKUP_PHRASE="oak indicate inside poet please share dinner monitor glow hire source perfect"
+$ export APP_GAIA_HUB="https://1.2.3.4"
+$ export PROFILE_GAIA_HUB="https://hub.blockstack.org"
+$ stx authenticator "$APP_GAIA_HUB" "$BACKUP_PHRASE" "$PROFILE_GAIA_HUB" 8888
+Press Ctrl+C to exit
+Authentication server started on 8888
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -59,17 +60,18 @@ Query the balance of an account.  Returns the balances of each kind of token tha
 
 Example:
 
-    $ stx balance 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4
-    {
-      "BTC": "123456"
-      "STACKS": "123456"
-    }
-    $ stx balance SPZY1V53Z4TVRHHW9Z7SFG8CZNRAG7BD8WJ6SXD0
-    {
-      "BTC": "123456"
-      "STACKS": "123456"
-    }
-
+```console
+$ stx balance 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4
+{
+  "BTC": "123456"
+  "STACKS": "123456"
+}
+$ stx balance SPZY1V53Z4TVRHHW9Z7SFG8CZNRAG7BD8WJ6SXD0
+{
+  "BTC": "123456"
+  "STACKS": "123456"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -83,11 +85,12 @@ Check if specified account can stack a number of Stacks tokens for given number 
 
 Example:
 
-    $ stx can_stack 10000000 20 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4 SPZY1V53Z4TVRHHW9Z7SFG8CZNRAG7BD8WJ6SXD0
-    {
-      "eligible": true
-    }
-
+```console
+$ stx can_stack 10000000 20 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4 SPZY1V53Z4TVRHHW9Z7SFG8CZNRAG7BD8WJ6SXD0
+{
+  "eligible": true
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -104,12 +107,15 @@ Call a function in a deployed Clarity smart contract.
 
 If the command succeeds, it prints out a transaction ID.
 Example:
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx call_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name      contract_function 1 0 "$PAYMENT"
-     {
-       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'     }
 
-
+```console
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx call_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name      contract_function 1 0 "$PAYMENT"
+{
+  txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
+  transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -128,9 +134,14 @@ Call a read-only function in a deployed Clarity smart contract.
 
 If the command succeeds, it prints out a Clarity value.
 Example:
-    $ stx call_read_only_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name     contract_function SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X
-     {
-       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'     }
+
+```console
+$ stx call_read_only_contract_func SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X contract_name     contract_function SPBMRFRPPGCDE3F384WCJPK8PQJGZ8K9QKK7F59X
+{
+  txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
+  transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+}
+```
 
 
 
@@ -149,43 +160,44 @@ Convert a Bitcoin address to a Stacks address and vice versa.
 
 Example:
 
-    $ stx convert_address 12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD
-    {
-      "mainnet": {
-        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
-        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
-      }
-    }
-    $ stx convert_address SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW
-    {
-      "mainnet": {
-        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
-        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
-      }
-    }
-    $ stx convert_address SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW -t
-    {
-      "mainnet": {
-        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
-        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
-      },
-      "testnet": {
-        "STACKS": "STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM",
-        "BTC": "mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo"
-      }
-    }
-    $ stx convert_address STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM
-    {
-      "mainnet": {
-        "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
-        "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
-      },
-      "testnet": {
-        "STACKS": "STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM",
-        "BTC": "mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo"
-      }
-    }
-
+```console
+$ stx convert_address 12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD
+{
+  "mainnet": {
+    "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
+    "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
+  }
+}
+$ stx convert_address SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW
+{
+  "mainnet": {
+    "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
+    "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
+  }
+}
+$ stx convert_address SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW -t
+{
+  "mainnet": {
+    "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
+    "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
+  },
+  "testnet": {
+    "STACKS": "STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM",
+    "BTC": "mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo"
+  }
+}
+$ stx convert_address STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM
+{
+  "mainnet": {
+    "STACKS": "SPA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7CBE6YPW",
+    "BTC": "12qdRgXxgNBNPnDeEChy3fYTbSHQ8nfZfD"
+  },
+  "testnet": {
+    "STACKS": "STA2MZWV9N67TBYVWTE0PSSKMJ2F6YXW7DX96QAM",
+    "BTC": "mhMaijcwVPcdAthFwmgLsaknTRt72GqQYo"
+  }
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -199,10 +211,12 @@ Decrypt an encrypted backup phrase with a password.  Decrypts to a 12-word backu
 
 Example:
 
-    $ # password is "asdf"
-    $ stx decrypt_keychain "bfMDtOucUGcJXjZo6vkrZWgEzue9fzPsZ7A6Pl4LQuxLI1xsVF0VPgBkMsnSLCmYS5YHh7R3mNtMmX45Bq9sNGPfPsseQMR0fD9XaHi+tBg=
-    Enter password:
-    section amount spend resemble spray verify night immune tattoo best emotion parrot
+```console
+$ # password is "asdf"
+$ stx decrypt_keychain "bfMDtOucUGcJXjZo6vkrZWgEzue9fzPsZ7A6Pl4LQuxLI1xsVF0VPgBkMsnSLCmYS5YHh7R3mNtMmX45Bq9sNGPfPsseQMR0fD9XaHi+tBg=
+Enter password:
+section amount spend resemble spray verify night immune tattoo best emotion parrot
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -250,11 +264,13 @@ Encrypt a 12-word backup phrase, which can be decrypted later with the `decrypt_
 
 Example:
 
-     $ # password is "asdf"
-     $ stx encrypt_keychain "section amount spend resemble spray verify night immune tattoo best emotion parrot"
-     Enter password:
-     Enter password again:
-     M+DnBHYb1fgw4N3oZ+5uTEAua5bAWkgTW/SjmmBhGGbJtjOtqVV+RrLJEJOgT35hBon4WKdGWye2vTdgqDo7+HIobwJwkQtN2YF9g3zPsKk=
+```console
+$ # password is "asdf"
+$ stx encrypt_keychain "section amount spend resemble spray verify night immune tattoo best emotion parrot"
+Enter password:
+Enter password again:
+M+DnBHYb1fgw4N3oZ+5uTEAua5bAWkgTW/SjmmBhGGbJtjOtqVV+RrLJEJOgT35hBon4WKdGWye2vTdgqDo7+HIobwJwkQtN2YF9g3zPsKk=
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -269,11 +285,13 @@ Encrypt a 12-word backup phrase, which can be decrypted later with the `decrypt_
 
 Example:
 
-     $ # password is "asdf"
-     $ blockstack-cli encrypt_keychain "section amount spend resemble spray verify night immune tattoo best emotion parrot"
-     Enter password:
-     Enter password again:
-     M+DnBHYb1fgw4N3oZ+5uTEAua5bAWkgTW/SjmmBhGGbJtjOtqVV+RrLJEJOgT35hBon4WKdGWye2vTdgqDo7+HIobwJwkQtN2YF9g3zPsKk=
+```console
+$ # password is "asdf"
+$ blockstack-cli encrypt_keychain "section amount spend resemble spray verify night immune tattoo best emotion parrot"
+Enter password:
+Enter password again:
+M+DnBHYb1fgw4N3oZ+5uTEAua5bAWkgTW/SjmmBhGGbJtjOtqVV+RrLJEJOgT35hBon4WKdGWye2vTdgqDo7+HIobwJwkQtN2YF9g3zPsKk=
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -287,14 +305,15 @@ Download the contents of a Gaia hub bucket to a given directory.  The `GAIA_HUB`
 
 Example:
 
-    $ export BACKUP_PHRASE="section amount spend resemble spray verify night immune tattoo best emotion parrot
-    $ stx gaia_dump_bucket hello.id.blockstack https://sample.app https://hub.blockstack.org "$BACKUP_PHRASE" ./backups
-    Download 3 files...
-    Download hello_world to ./backups/hello_world
-    Download dir/format to ./backups/dir\x2fformat
-    Download /.dotfile to ./backups/\x2f.dotfile
-    3
-
+```console
+$ export BACKUP_PHRASE="section amount spend resemble spray verify night immune tattoo best emotion parrot
+$ stx gaia_dump_bucket hello.id.blockstack https://sample.app https://hub.blockstack.org "$BACKUP_PHRASE" ./backups
+Download 3 files...
+Download hello_world to ./backups/hello_world
+Download dir/format to ./backups/dir\x2fformat
+Download /.dotfile to ./backups/\x2f.dotfile
+3
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -314,19 +333,22 @@ Gaia is a key-value store, so it does not have any built-in notion of directorie
 
 Example without encryption:
 
-    $ # Get an unencrypted, unsigned file
-    $ stx gaia_getfile ryan.id http://public.ykliao.com statuses.json
-    [{"id":0,"text":"Hello, Blockstack!","created_at":1515786983492}]
+```console
+$ # Get an unencrypted, unsigned file
+$ stx gaia_getfile ryan.id http://public.ykliao.com statuses.json
+[{"id":0,"text":"Hello, Blockstack!","created_at":1515786983492}]
+```
 
 Example with encryption:
 
-    $ # Get an encrypted file without decrypting
-    $ stx gaia_getfile ryan.id https://app.graphitedocs.com documentscollection.json
-        $ # Get an encrypted file, and decrypt it
-    $ # Tip: You can obtain the app key with the get_app_keys command
-    $ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
-    $ stx gaia_getfile ryan.id https://app.graphitedocs.com documentscollection.json "$APP_KEY" 1 0
-
+```console
+$ # Get an encrypted file without decrypting
+$ stx gaia_getfile ryan.id https://app.graphitedocs.com documentscollection.json
+$ # Get an encrypted file, and decrypt it
+$ # Tip: You can obtain the app key with the get_app_keys command
+$ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
+ $ stx gaia_getfile ryan.id https://app.graphitedocs.com documentscollection.json "$APP_KEY" 1 0
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -347,26 +369,27 @@ Gaia is a key-value store, so it does not have any built-in notion of directorie
 
 Example:
 
-    $ # Store 4 versions of a file: plaintext, encrypted, signed, and encrypted+signed
-    $ # Tip: You can obtain the app key with the get_app_keys command.
-    $ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
-    $ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file.txt
-    {
-       "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file.txt"
-    }
-    $ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file-encrypted.txt 1
-    {
-       "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file-encrypted.txt"
-    }
-    $ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file-signed.txt 0 1
-    {
-       "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file-signed.txt"
-    }
-    $ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file-encrypted-signed.txt 1 1
-    {
-       "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file-encrypted-signed.txt"
-    }
-
+```console
+$ # Store 4 versions of a file: plaintext, encrypted, signed, and encrypted+signed
+$ # Tip: You can obtain the app key with the get_app_keys command.
+$ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
+$ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file.txt
+{
+   "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file.txt"
+}
+$ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file-encrypted.txt 1
+{
+   "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file-encrypted.txt"
+}
+$ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file-signed.txt 0 1
+{
+   "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file-signed.txt"
+}
+$ stx gaia_putfile https://hub.blockstack.org "$APP_KEY" /path/to/file.txt file-encrypted-signed.txt 1 1
+{
+   "urls": "https://gaia.blockstack.org/hub/19KAzYp4kSKozeAGMUsnuqkEGdgQQLEvwo/file-encrypted-signed.txt"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -384,10 +407,12 @@ Example:
 Delete a file in a Gaia hub, as well as its signature metadata (which is stored in a separate file).
 Example:
 
-    $ # Tip: You can obtain the app key with the get_app_keys command.
-    $ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
-    $ stx gaia_deletefile https://hub.blockstack.org "$APP_KEY" file.txt false
-    ok
+```console
+$ # Tip: You can obtain the app key with the get_app_keys command.
+$ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
+$ stx gaia_deletefile https://hub.blockstack.org "$APP_KEY" file.txt false
+ok
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -404,14 +429,15 @@ List all the files in a Gaia hub bucket.  You must have the private key for the 
 
 Example:
 
-    $ # Tip: You can obtain the app key with the get_app_keys command.
-    $ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
-    $ stx gaia_listfiles "https://hub.blockstack.org" "$APP_KEY"
-    hello_world
-    dir/format
-    /.dotfile
-    3
-
+```console
+$ # Tip: You can obtain the app key with the get_app_keys command.
+$ export APP_KEY="3ac770e8c3d88b1003bf4a0a148ceb920a6172bdade8e0325a1ed1480ab4fb19"
+$ stx gaia_listfiles "https://hub.blockstack.org" "$APP_KEY"
+hello_world
+dir/format
+/.dotfile
+3
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -426,13 +452,14 @@ Upload the contents of a previously-dumped Gaia bucket to a new Gaia hub.  The `
 
 Example:
 
-    $ export BACKUP_PHRASE="section amount spend resemble spray verify night immune tattoo best emotion parrot"
-    $ stx gaia_restore_bucket hello.id.blockstack https://sample.app https://new.gaia.hub "$BACKUP_PHRASE" ./backups
-    Uploaded ./backups/hello_world to https://new.gaia.hub/hub/1Lr8ggSgdmfcb4764woYutUfFqQMjEoKHc/hello_world
-    Uploaded ./backups/dir\x2fformat to https://new.gaia.hub/hub/1Lr8ggSgdmfcb4764woYutUfFqQMjEoKHc/dir/format
-    Uploaded ./backups/\x2f.dotfile to https://new.gaia.hub/hub/1Lr8ggSgdmfcb4764woYutUfFqQMjEoKHc//.dotfile
-    3
-
+```console
+$ export BACKUP_PHRASE="section amount spend resemble spray verify night immune tattoo best emotion parrot"
+$ stx gaia_restore_bucket hello.id.blockstack https://sample.app https://new.gaia.hub "$BACKUP_PHRASE" ./backups
+Uploaded ./backups/hello_world to https://new.gaia.hub/hub/1Lr8ggSgdmfcb4764woYutUfFqQMjEoKHc/hello_world
+Uploaded ./backups/dir\x2fformat to https://new.gaia.hub/hub/1Lr8ggSgdmfcb4764woYutUfFqQMjEoKHc/dir/format
+Uploaded ./backups/\x2f.dotfile to https://new.gaia.hub/hub/1Lr8ggSgdmfcb4764woYutUfFqQMjEoKHc//.dotfile
+3
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -454,23 +481,24 @@ Your 12-word phrase (in either raw or encrypted form) is required to re-sign and
 
 Example:
 
-    $ export BACKUP_PHRASE="soap fog wealth upon actual blossom neither timber phone exile monkey vocal"
-    $ stx gaia_sethub hello_world.id https://hub.blockstack.org https://my.cool.app https://my.app.gaia.hub "$BACKUP_PHRASE"
-    {
-      "profileUrls": {
-        "error": null,
-        "dataUrls": [
-          "https://gaia.blockstack.org/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json"
-        ]
-      }
-    }
-    
-    $ # You can check the new apps entry with curl and jq as follows:
-    $ curl -sL https://gaia.blockstack.org/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json | jq ".[0].decodedToken.payload.claim.apps"
-    {
-      "https://my.cool.app": "https://my.app.gaia.hub/hub/1EqzyQLJ15KG1WQmi5cf1HtmSeqS1Wb8tY/"
-    }
+```console
+$ export BACKUP_PHRASE="soap fog wealth upon actual blossom neither timber phone exile monkey vocal"
+$ stx gaia_sethub hello_world.id https://hub.blockstack.org https://my.cool.app https://my.app.gaia.hub "$BACKUP_PHRASE"
+{
+  "profileUrls": {
+    "error": null,
+    "dataUrls": [
+      "https://gaia.blockstack.org/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json"
+    ]
+  }
+}
 
+$ # You can check the new apps entry with curl and jq as follows:
+$ curl -sL https://gaia.blockstack.org/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json | jq ".[0].decodedToken.payload.claim.apps"
+{
+  "https://my.cool.app": "https://my.app.gaia.hub/hub/1EqzyQLJ15KG1WQmi5cf1HtmSeqS1Wb8tY/"
+}
+```
 
 
 | Name | Type | Value |
@@ -489,51 +517,51 @@ Query the history of account debits and credits over a given block range.  Retur
 
 Example:
 
-    $ stx get_account_history SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA 0
-    [
-      {
-        "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
-        "block_id": 56789
-        "credit_value": "100000000000",
-        "debit_value": "0",
-        "lock_transfer_block_id": 0,
-        "txid": "0e5db84d94adff5b771262b9df015164703b39bb4a70bf499a1602b858a0a5a1",
-        "type": "STACKS",
-        "vtxindex": 0
-      },
-      {
-        "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
-        "block_id": 56790,
-        "credit_value": "100000000000",
-        "debit_value": "64000000000",
-        "lock_transfer_block_id": 0,
-        "txid": "5a0c67144626f7bd4514e4de3f3bbf251383ca13887444f326bac4bc8b8060ee",
-        "type": "STACKS",
-        "vtxindex": 1
-      },
-      {
-        "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
-        "block_id": 56791,
-        "credit_value": "100000000000",
-        "debit_value": "70400000000",
-        "lock_transfer_block_id": 0,
-        "txid": "e54c271d6a9feb4d1859d32bc99ffd713493282adef5b4fbf50bca9e33fc0ecc",
-        "type": "STACKS",
-        "vtxindex": 2
-      },
-      {
-        "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
-        "block_id": 56792,
-        "credit_value": "100000000000",
-        "debit_value": "76800000000",
-        "lock_transfer_block_id": 0,
-        "txid": "06e0d313261baefec1e59783e256ab487e17e0e776e2fdab0920cc624537e3c8",
-        "type": "STACKS",
-        "vtxindex": 3
-      }
-    ]
-
-
+```console
+$ stx get_account_history SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA 0
+[
+  {
+    "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
+    "block_id": 56789
+    "credit_value": "100000000000",
+    "debit_value": "0",
+    "lock_transfer_block_id": 0,
+    "txid": "0e5db84d94adff5b771262b9df015164703b39bb4a70bf499a1602b858a0a5a1",
+    "type": "STACKS",
+    "vtxindex": 0
+  },
+  {
+    "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
+    "block_id": 56790,
+    "credit_value": "100000000000",
+    "debit_value": "64000000000",
+    "lock_transfer_block_id": 0,
+    "txid": "5a0c67144626f7bd4514e4de3f3bbf251383ca13887444f326bac4bc8b8060ee",
+    "type": "STACKS",
+    "vtxindex": 1
+  },
+  {
+    "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
+    "block_id": 56791,
+    "credit_value": "100000000000",
+    "debit_value": "70400000000",
+    "lock_transfer_block_id": 0,
+    "txid": "e54c271d6a9feb4d1859d32bc99ffd713493282adef5b4fbf50bca9e33fc0ecc",
+    "type": "STACKS",
+    "vtxindex": 2
+  },
+  {
+    "address": "SP2H7VMY13ESQDAD5808QEY1EMGESMHZWBJRTN2YA",
+    "block_id": 56792,
+    "credit_value": "100000000000",
+    "debit_value": "76800000000",
+    "lock_transfer_block_id": 0,
+    "txid": "06e0d313261baefec1e59783e256ab487e17e0e776e2fdab0920cc624537e3c8",
+    "type": "STACKS",
+    "vtxindex": 3
+  }
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -548,21 +576,21 @@ Query the list of token debits and credits on a given address that occurred at a
 
 Example
 
-    $ stx -t get_account_at SP2NTAQFECYGSTE1W47P71FG21H8F00KZZWFGEVKQ 56789
-    [
-      {
-        "debit_value": "0",
-        "block_id": 56789
-        "lock_transfer_block_id": 0,
-        "txid": "291817c78a865c1f72938695218a48174265b2358e89b9448edc89ceefd66aa0",
-        "address": "SP2NTAQFECYGSTE1W47P71FG21H8F00KZZWFGEVKQ",
-        "credit_value": "1000000000000000000",
-        "type": "STACKS",
-        "vtxindex": 0
-      }
-    ]
-
-
+```console
+$ stx -t get_account_at SP2NTAQFECYGSTE1W47P71FG21H8F00KZZWFGEVKQ 56789
+[
+  {
+    "debit_value": "0",
+    "block_id": 56789
+    "lock_transfer_block_id": 0,
+    "txid": "291817c78a865c1f72938695218a48174265b2358e89b9448edc89ceefd66aa0",
+    "address": "SP2NTAQFECYGSTE1W47P71FG21H8F00KZZWFGEVKQ",
+    "credit_value": "1000000000000000000",
+    "type": "STACKS",
+    "vtxindex": 0
+  }
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -577,16 +605,18 @@ Get the address of a private key or multisig private key bundle.  Gives the BTC 
 
 Example:
 
-    $ stx get_address f5185b9ca93bdcb5753fded3b097dab8547a8b47d2be578412d0687a9a0184cb01
-    {
-      "BTC": "1JFhWyVPpZQjbPcXFtpGtTmU22u4fhBVmq",
-      "STACKS": "SP2YM3J4KQK09V670TD6ZZ1XYNYCNGCWCVVKSDFWQ"
-    }
-    $ stx get_address 1,f5185b9ca93bdcb5753fded3b097dab8547a8b47d2be578412d0687a9a0184cb01,ff2ff4f4e7f8a1979ffad4fc869def1657fd5d48fc9cf40c1924725ead60942c01
-    {
-      "BTC": "363pKBhc5ipDws1k5181KFf6RSxhBZ7e3p",
-      "STACKS": "SMQWZ30EXVG6XEC1K4QTDP16C1CAWSK1JSWMS0QN"
-    }
+```console
+$ stx get_address f5185b9ca93bdcb5753fded3b097dab8547a8b47d2be578412d0687a9a0184cb01
+{
+  "BTC": "1JFhWyVPpZQjbPcXFtpGtTmU22u4fhBVmq",
+  "STACKS": "SP2YM3J4KQK09V670TD6ZZ1XYNYCNGCWCVVKSDFWQ"
+}
+$ stx get_address 1,f5185b9ca93bdcb5753fded3b097dab8547a8b47d2be578412d0687a9a0184cb01,ff2ff4f4e7f8a1979ffad4fc869def1657fd5d48fc9cf40c1924725ead60942c01
+{
+  "BTC": "363pKBhc5ipDws1k5181KFf6RSxhBZ7e3p",
+  "STACKS": "SMQWZ30EXVG6XEC1K4QTDP16C1CAWSK1JSWMS0QN"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -621,13 +651,13 @@ Get the block height and number of confirmations for a transaction.
 
 Example:
 
-    $ stx get_confirmations e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
-    {
-      "blockHeight": 567890,
-      "confirmations": 7,
-    }
-
-
+```console
+$ stx get_confirmations e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
+{
+  "blockHeight": 567890,
+  "confirmations": 7,
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -650,14 +680,16 @@ Get the low-level blockchain-hosted state for a Blockstack namespace.  This comm
 Get the application private key from a 12- or 24-word Secret Key and an index of the enumerated associated accounts.  This is the private key used to sign data in Gaia, and its address is the Gaia bucket address.  If you provide your encrypted backup phrase, you will be asked to decrypt it.  
 Example:
 
-    $ export BACKUP_PHRASE="one race buffalo dynamic icon drip width lake extra forest fee kit"
-    $ stx get_app_keys "$BACKUP_PHRASE" 1 https://my.cool.dapp
-    {
-      "keyInfo": {
-        "privateKey": "TODO",
-        "address": "TODO"
-      },
-    }
+```console
+$ export BACKUP_PHRASE="one race buffalo dynamic icon drip width lake extra forest fee kit"
+$ stx get_app_keys "$BACKUP_PHRASE" 1 https://my.cool.dapp
+{
+  "keyInfo": {
+    "privateKey": "TODO",
+    "address": "TODO"
+  },
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -673,31 +705,31 @@ Get the list of owner private keys and ID-addresses from a 12-word backup phrase
 
 Example:
 
-    $ # get the first 3 owner keys and addresses for a backup phrase
-    $ export BACKUP_PHRASE="soap fog wealth upon actual blossom neither timber phone exile monkey vocal"
-    $ stx get_owner_keys "$BACKUP_PHRASE" 3
-    [
-      {
-        "privateKey": "14b0811d5cd3486d47279d8f3a97008647c64586b121e99862c18863e2a4183501",
-        "version": "v0.10-current",
-        "index": 0,
-        "idAddress": "ID-1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82"
-      },
-      {
-        "privateKey": "1b3572d8dd6866828281ac6cf135f04153210c1f9b123743eccb795fd3095e4901",
-        "version": "v0.10-current",
-        "index": 1,
-        "idAddress": "ID-18pR3UpD1KFrnk88a3MGZmG2dLuZmbJZ25"
-      },
-      {
-        "privateKey": "b19b6d62356db96d570fb5f08b78f0aa7f384525ba3bdcb96fbde29b8e11710d01",
-        "version": "v0.10-current",
-        "index": 2,
-        "idAddress": "ID-1Gx4s7ggkjENw3wSY6bNd1CwoQKk857AqN"
-      }
-    ]
-
-
+```console
+$ # get the first 3 owner keys and addresses for a backup phrase
+$ export BACKUP_PHRASE="soap fog wealth upon actual blossom neither timber phone exile monkey vocal"
+$ stx get_owner_keys "$BACKUP_PHRASE" 3
+[
+  {
+    "privateKey": "14b0811d5cd3486d47279d8f3a97008647c64586b121e99862c18863e2a4183501",
+    "version": "v0.10-current",
+    "index": 0,
+    "idAddress": "ID-1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82"
+  },
+  {
+    "privateKey": "1b3572d8dd6866828281ac6cf135f04153210c1f9b123743eccb795fd3095e4901",
+    "version": "v0.10-current",
+    "index": 1,
+    "idAddress": "ID-18pR3UpD1KFrnk88a3MGZmG2dLuZmbJZ25"
+  },
+  {
+    "privateKey": "b19b6d62356db96d570fb5f08b78f0aa7f384525ba3bdcb96fbde29b8e11710d01",
+    "version": "v0.10-current",
+    "index": 2,
+    "idAddress": "ID-1Gx4s7ggkjENw3wSY6bNd1CwoQKk857AqN"
+  }
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -712,19 +744,19 @@ Get the payment private key from a 12-word backup phrase.  If you provide an enc
 
 Example
 
-    $ stx get_payment_key "soap fog wealth upon actual blossom neither timber phone exile monkey vocal"
-    [
-      {
-        "privateKey": "4023435e33da4aff0775f33e7b258f257fb20ecff039c919b5782313ab73afb401",
-        "address": {
-          "BTC": "1ybaP1gaRwRSWRE4f8JXo2W8fiTZmA4rV",
-          "STACKS": "SP5B89ZJAQHBRXVYP15YB5PAY5E24FEW9K4Q63PE"
-        },
-        "index": 0
-      }
-    ]
-
-
+```console
+$ stx get_payment_key "soap fog wealth upon actual blossom neither timber phone exile monkey vocal"
+[
+  {
+    "privateKey": "4023435e33da4aff0775f33e7b258f257fb20ecff039c919b5782313ab73afb401",
+    "address": {
+      "BTC": "1ybaP1gaRwRSWRE4f8JXo2W8fiTZmA4rV",
+      "STACKS": "SP5B89ZJAQHBRXVYP15YB5PAY5E24FEW9K4Q63PE"
+    },
+    "index": 0
+  }
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -738,19 +770,19 @@ Get the payment private key from a 24-word backup phrase used by the Stacks wall
 
 Example
 
-    $ stx get_stacks_wallet_key "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"
-    [
-      {
-        "privateKey": "a25cea8d310ce656c6d427068c77bad58327334f73e39c296508b06589bc4fa201",
-        "address": {
-          "BTC": "1ATAW6TAbTCKgU3xPgAcWQwjW9Q26Eambx",
-          "STACKS": "SP1KTQR7CTQNA20SV2VNTF9YABMR6RJERSES3KC6Z"
-        },
-        "index": 0
-      }
-    ]
-
-
+```console
+$ stx get_stacks_wallet_key "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise"
+[
+  {
+    "privateKey": "a25cea8d310ce656c6d427068c77bad58327334f73e39c296508b06589bc4fa201",
+    "address": {
+      "BTC": "1ATAW6TAbTCKgU3xPgAcWQwjW9Q26Eambx",
+      "STACKS": "SP1KTQR7CTQNA20SV2VNTF9YABMR6RJERSES3KC6Z"
+    },
+    "index": 0
+  }
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -784,9 +816,9 @@ This command performs these steps in sequence:
 
 Example
 
-    $ stx migrate_subdomains "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise" https://registrar.stacks.co
-
-
+```console
+$ stx migrate_subdomains "toast canal educate tissue express melody produce later gospel victory meadow outdoor hollow catch liberty annual gasp hat hello april equip thank neck cruise" https://registrar.stacks.co
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -801,12 +833,12 @@ Get a zone file by hash.
 
 Example:
 
-    $ stx get_zonefile ee77ad484b7b229f09461e4c2b6d3bd3e152ba95
-    $ORIGIN ryanshea.id
-    $TTL 3600
-    _http._tcp URI 10 1 "https://gaia.blockstack.org/hub/15BcxePn59Y6mYD2fRLCLCaaHScefqW2No/1/profile.json"
-
-
+```console
+$ stx get_zonefile ee77ad484b7b229f09461e4c2b6d3bd3e152ba95
+$ORIGIN ryanshea.id
+$TTL 3600
+_http._tcp URI 10 1 "https://gaia.blockstack.org/hub/15BcxePn59Y6mYD2fRLCLCaaHScefqW2No/1/profile.json"
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -830,9 +862,9 @@ Get and authenticate the profile and zone file for a Blockstack ID.
 
 Example:
 
-    $ stx lookup example.id
-
-
+```console
+$ stx lookup example.id
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -846,9 +878,9 @@ Get the list of Blockstack IDs owned by an ID-address.
 
 Example:
 
-    $ stx names ID-1FpBChfzHG3TdQQRKWAipbLragCUArueG9
-
-
+```console
+$ stx names ID-1FpBChfzHG3TdQQRKWAipbLragCUArueG9
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -862,19 +894,19 @@ Generate the owner and payment private keys, optionally from a given 12-word bac
 
 Example:
 
-    $ stx make_keychain
-    {
-      "mnemonic": "apart spin rich leader siren foil dish sausage fee pipe ethics bundle",
-      "keyInfo": {
-        "privateKey": "25899fab1b9b95cc2d1692529f00fb788e85664df3d14db1a660f33c5f96d8ab01"
-        "address": "SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7"
-        "btcAddress": "1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki"
-        "wif": "KxUgLbeVeFZEUUQpc3ncYn5KFB3WH5MVRv3SJ2g5yPwkrXs3QRaP"
-        "index": 0,
-      }
-    }
-
-
+```console
+$ stx make_keychain
+{
+  "mnemonic": "apart spin rich leader siren foil dish sausage fee pipe ethics bundle",
+  "keyInfo": {
+    "privateKey": "25899fab1b9b95cc2d1692529f00fb788e85664df3d14db1a660f33c5f96d8ab01"
+    "address": "SP3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFS0AYVF7"
+    "btcAddress": "1Nwxfx7VoYAg2mEN35dTRw4H7gte8ajFki"
+    "wif": "KxUgLbeVeFZEUUQpc3ncYn5KFB3WH5MVRv3SJ2g5yPwkrXs3QRaP"
+    "index": 0,
+  }
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -887,18 +919,20 @@ Example:
 
 Generate a zone file for a Blockstack ID with the given profile URL.  If you know the ID-address for the Blockstack ID, the profile URL usually takes the form of:
 
-     {GAIA_URL_PREFIX}/{ADDRESS}/profile.json
+```
+{GAIA_URL_PREFIX}/{ADDRESS}/profile.json
+```
 
 where `{GAIA_URL_PREFIX}` is the *read* endpoint of your Gaia hub (e.g. https://gaia.blockstack.org/hub) and `{ADDRESS}` is the base58check part of your ID-address (i.e. the string following 'ID-').
 
 Example:
 
-     $ stx make_zonefile example.id ID-1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82 https://my.gaia.hub/hub
-     $ORIGIN example.id
-     $TTL 3600
-     _http._tcp      IN      URI     10      1       "https://my.gaia.hub/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json"
-
-
+```console
+$ stx make_zonefile example.id ID-1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82 https://my.gaia.hub/hub
+$ORIGIN example.id
+$TTL 3600
+_http._tcp      IN      URI     10      1       "https://my.gaia.hub/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json"
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -923,12 +957,12 @@ This command prints out a transaction ID if it succeeds, and it replicates the z
 
 Example:
 
-    $ export REVEAL_KEY="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ export ID_ADDRESS="ID-18e1bqU7B5qUPY3zJgMLxDnexyStTeSnvV"
-    $ stx name_import example.id "$ID_ADDRESS" https://gaia.blockstack.org/hub "$REVEAL_KEY"
-    f726309cea7a9db364307466dc0e0e759d5c0d6bad1405e2fd970740adc7dc45
-
-
+```console
+$ export REVEAL_KEY="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ export ID_ADDRESS="ID-18e1bqU7B5qUPY3zJgMLxDnexyStTeSnvV"
+$ stx name_import example.id "$ID_ADDRESS" https://gaia.blockstack.org/hub "$REVEAL_KEY"
+f726309cea7a9db364307466dc0e0e759d5c0d6bad1405e2fd970740adc7dc45
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -989,13 +1023,13 @@ Get the price of an on-chain Blockstack ID.  Its namespace must already exist.
 
 Example:
 
-    $ stx price example.id
-    {
-      "units": "BTC",
-      "amount": "5500"
-    }
-
-
+```console
+$ stx price example.id
+{
+  "units": "BTC",
+  "amount": "5500"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1009,14 +1043,14 @@ Get the price of a namespace.
 
 Example:
 
-    $ # get the price of the .hello namespace
-    $ stx price_namespace hello
-    {
-      "units": "BTC",
-      "amount": "40000000"
-    }
-
-
+```console
+$ # get the price of the .hello namespace
+$ stx price_namespace hello
+{
+  "units": "BTC",
+  "amount": "40000000"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1030,10 +1064,10 @@ Sign a profile on disk with a given owner private key.  Print out the signed pro
 
 Example:
 
-    $ # Tip: you can get the owner key from your 12-word backup phrase using the get_owner_keys command
-    $ stx profile_sign /path/to/profile.json 0ffd299af9c257173be8486ef54a4dd1373407d0629ca25ca68ff24a76be09fb01
-
-
+```console
+$ # Tip: you can get the owner key from your 12-word backup phrase using the get_owner_keys command
+$ stx profile_sign /path/to/profile.json 0ffd299af9c257173be8486ef54a4dd1373407d0629ca25ca68ff24a76be09fb01
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1061,12 +1095,12 @@ Verify a JWT encoding a profile on disk using an ID-address.  Prints out the con
 
 Example:
 
-    $ # get the raw profile JWT
-    $ curl -sL https://raw.githubusercontent.com/jcnelson/profile/master/judecn.id > /tmp/judecn.id.jwt
-    $ # Tip: you can get the ID-address for a name with the "whois" command
-    $ stx profile_verify /tmp/judecn.id.jwt ID-16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg
-
-
+```console
+$ # get the raw profile JWT
+$ curl -sL https://raw.githubusercontent.com/jcnelson/profile/master/judecn.id > /tmp/judecn.id.jwt
+$ # Tip: you can get the ID-address for a name with the "whois" command
+$ stx profile_verify /tmp/judecn.id.jwt ID-16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1083,35 +1117,35 @@ If you create a new zonefile for your name, you will need to later use `zonefile
 
 Example:
 
-    $ # Tip: you can get your owner key from your backup phrase with "get_owner_keys".
-    $ # Tip: you can get your payment key from your backup phrase with "get_payment_key".
-    $ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx renew hello_world.id "$OWNER" "$PAYMENT"
-    3d8945ce76d4261678d76592b472ed639a10d4298f9d730af4edbbc3ec02882e
+```console
+$ # Tip: you can get your owner key from your backup phrase with "get_owner_keys".
+$ # Tip: you can get your payment key from your backup phrase with "get_payment_key".
+$ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx renew hello_world.id "$OWNER" "$PAYMENT"
+3d8945ce76d4261678d76592b472ed639a10d4298f9d730af4edbbc3ec02882e
 
-    $ # Renew with a new owner
-    $ export NEW_OWNER="ID-141BcmFVbEuuMb7Bd6umXyV6ZD1WYomYDE"
-    $ stx renew hello_world.id "$OWNER" "$PAYMENT" "$NEW_OWNER"
-    33865625ef3f1b607111c0dfba9e58604927173bd2e299a343e19aa6d2cfb263
+$ # Renew with a new owner
+$ export NEW_OWNER="ID-141BcmFVbEuuMb7Bd6umXyV6ZD1WYomYDE"
+$ stx renew hello_world.id "$OWNER" "$PAYMENT" "$NEW_OWNER"
+33865625ef3f1b607111c0dfba9e58604927173bd2e299a343e19aa6d2cfb263
 
-    $ # Renew with a new zone file.
-    $ # Tip: you can create a new zonefile with the "make_zonefile" command.
-    $ export ZONEFILE_PATH="/path/to/new/zonefile.txt"
-    $ stx renew hello_world.id "$OWNER" "$PAYMENT" --zonefile "$ZONEFILE_PATH"
-    e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
-    $ # wait 7 confirmations
-    $ stx get_confirmations e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
-    {
-      "blockHeight": 567890,
-      "confirmations": 7,
-    }
-    $ stx -H https://stacks-node-api.stacks.co zonefile_push "$ZONEFILE_PATH"
-    [
-      "https://stacks-node-api.stacks.co"
-    ]
-
-
+$ # Renew with a new zone file.
+$ # Tip: you can create a new zonefile with the "make_zonefile" command.
+$ export ZONEFILE_PATH="/path/to/new/zonefile.txt"
+$ stx renew hello_world.id "$OWNER" "$PAYMENT" --zonefile "$ZONEFILE_PATH"
+e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
+$ # wait 7 confirmations
+$ stx get_confirmations e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
+{
+  "blockHeight": 567890,
+  "confirmations": 7,
+}
+$ stx -H https://stacks-node-api.stacks.co zonefile_push "$ZONEFILE_PATH"
+[
+  "https://stacks-node-api.stacks.co"
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1140,9 +1174,10 @@ WARNING: You should *NOT* use the payment private key (`PAYMENT_KEY`) while the 
 
 Example:
 
-    $ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
-    $ stx register example.id "$OWNER" salt zonfile
-
+```console
+$ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
+$ stx register example.id "$OWNER" salt zonfile
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1171,9 +1206,11 @@ WARNING: You should *NOT* use the payment private key (`PAYMENT_KEY`) while the 
 
 Example:
 
-    $ export ID_ADDRESS="ID-18e1bqU7B5qUPY3zJgMLxDnexyStTeSnvV"
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx register_addr example.id "$ID_ADDRESS" "$PAYMENT" https://gaia.blockstack.org/hub
+```console
+$ export ID_ADDRESS="ID-18e1bqU7B5qUPY3zJgMLxDnexyStTeSnvV"
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx register_addr example.id "$ID_ADDRESS" "$PAYMENT" https://gaia.blockstack.org/hub
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1191,13 +1228,13 @@ Revoke a name.  This renders it unusable until it expires (if ever).  This comma
 
 Example:
 
-    $ # Tip: you can get your owner and payment keys from your 12-word backup phrase using the get_owner_keys and get_payment_key commands.
-    $ export OWNER="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx revoke example.id "$OWNER" "$PAYMENT"
-    233b559c97891affa010567bd582110508d0236b4e3f88d3b1d0731629e030b0
-
-
+```console
+$ # Tip: you can get your owner and payment keys from your 12-word backup phrase using the get_owner_keys and get_payment_key commands.
+$ export OWNER="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx revoke example.id "$OWNER" "$PAYMENT"
+233b559c97891affa010567bd582110508d0236b4e3f88d3b1d0731629e030b0
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1215,11 +1252,11 @@ If the command succeeds, it prints out the transaction ID.  You can track its co
 
 Example:
 
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx send_btc 18qTSE5PPQmypwKKej7QX5Db2XAttgYeA1 123456 "$PAYMENT"
-    c7e239fd24da30e36e011e6bc7db153574a5b40a3a8dc3b727adb54ad038acc5
-
-
+```console
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx send_btc 18qTSE5PPQmypwKKej7QX5Db2XAttgYeA1 123456 "$PAYMENT"
+c7e239fd24da30e36e011e6bc7db153574a5b40a3a8dc3b727adb54ad038acc5
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1237,36 +1274,36 @@ If the command succeeds, it prints out a transaction ID.  You can track the conf
 
 Example:
 
-    $ # check balances of sender and recipient before sending.
-    $ # address of the key below is SP2SC16ASH76GX549PT7J5WQZA4GHMFBKYMBQFF9V
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx balance SP2SC16ASH76GX549PT7J5WQZA4GHMFBKYMBQFF9V
-    {
-      "STACKS": "10000000"
-    }
-    $ stx balance SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY
-    {
-      "STACKS": "0"
-    }
+```console
+$ # check balances of sender and recipient before sending.
+$ # address of the key below is SP2SC16ASH76GX549PT7J5WQZA4GHMFBKYMBQFF9V
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx balance SP2SC16ASH76GX549PT7J5WQZA4GHMFBKYMBQFF9V
+{
+  "STACKS": "10000000"
+}
+$ stx balance SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY
+{
+  "STACKS": "0"
+}
 
-    $ # send tokens
-    $ stx send_tokens SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY 12345 1 0 "$PAYMENT"
-     {
-       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'     }
-    a9d387a925fb0ba7a725fb1e11f2c3f1647473699dd5a147c312e6453d233456
+$ # send tokens
+$ stx send_tokens SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY 12345 1 0 "$PAYMENT"
+ {
+   txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'     }
+a9d387a925fb0ba7a725fb1e11f2c3f1647473699dd5a147c312e6453d233456
 
-    $ # wait for transaction to be confirmed
+$ # wait for transaction to be confirmed
 
-    $ stx balance SP2SC16ASH76GX549PT7J5WQZA4GHMFBKYMBQFF9V
-    {
-      "STACKS": "9987655"
-    }
-    $ stx balance SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY
-    {
-      "STACKS": "12345"
-    }
-
-
+$ stx balance SP2SC16ASH76GX549PT7J5WQZA4GHMFBKYMBQFF9V
+{
+  "STACKS": "9987655"
+}
+$ stx balance SP1P10PS2T517S4SQGZT5WNX8R00G1ECTRKYCPMHY
+{
+  "STACKS": "12345"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1285,10 +1322,13 @@ Stack the specified number of Stacks tokens for given number of cycles.
 
 Example:
 
-    $ stx stack 10000000 20 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4 136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01
-     {
-       txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',       transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'     }
-
+```console
+$ stx stack 10000000 20 16pm276FpJYpm7Dv3GEaRqTVvGPTdceoY4 136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01
+{
+  txid: '0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1',
+  transaction: 'https://explorer.hiro.so/txid/0x2e33ad647a9cedacb718ce247967dc705bc0c878db899fdba5eae2437c6fa1e1'
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1307,8 +1347,9 @@ Get stacking status for specified address.
 
 Example:
 
-    $ stx stacking_status SPZY1V53Z4TVRHHW9Z7SFG8CZNRAG7BD8WJ6SXD0
-
+```console
+$ stx stacking_status SPZY1V53Z4TVRHHW9Z7SFG8CZNRAG7BD8WJ6SXD0
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1326,14 +1367,14 @@ An ID-address can only own up to 25 Blockstack IDs.  In practice, you should gen
 
 Example:
 
-    $ # Tip: you can get your owner key from your backup phrase with "get_owner_keys".
-    $ # Tip: you can get your payment key from your backup phrase with "get_payment_key".
-    $ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ stx transfer example.id ID-1HJA1AJvWef21XbQVL2AcTv71b6JHGPfDX true "$OWNER" "$PAYMENT"
-    e09dc158e586d0c09dbcdcba917ec394e6c6ac2b9c91c4b55f32f5973e4f08fc
-
-
+```console
+$ # Tip: you can get your owner key from your backup phrase with "get_owner_keys".
+$ # Tip: you can get your payment key from your backup phrase with "get_payment_key".
+$ export OWNER="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ stx transfer example.id ID-1HJA1AJvWef21XbQVL2AcTv71b6JHGPfDX true "$OWNER" "$PAYMENT"
+e09dc158e586d0c09dbcdcba917ec394e6c6ac2b9c91c4b55f32f5973e4f08fc
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1353,9 +1394,10 @@ This is a low-level command that only experienced Blockstack developers should u
 
 Example:
 
-    $ export PAYMENT="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
-    $ stx tx_preorder example.id "$PAYMENT" salt 1000
-
+```console
+$ export PAYMENT="136ff26efa5db6f06b28f9c8c7a0216a1a52598045162abfe435d13036154a1b01"
+$ stx tx_preorder example.id "$PAYMENT" salt 1000
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1392,30 +1434,30 @@ Once the transaction confirms, you will need to replicate the zone file to the B
 
 Example:
 
-    $ # Tip: you can get your owner and payment keys from your 12-word backup phrase using the get_owner_keys and get_payment_key commands.
-    $ export OWNER="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"
-    $ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
-    $ # make a new zone file
-    $ stx make_zonefile example.id ID-1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82 https://my.gaia.hub/hub > /tmp/zonefile.txt
-    
-    $ # update the name to reference this new zone file
-    $ stx update example.id /tmp/zonefile.txt "$OWNER" "$PAYMENT"
-    8e94a5b6647276727a343713d3213d587836e1322b1e38bc158406f5f8ebe3fd
-    
-    $ # check confirmations
-    $ stx get_confirmations e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
-    {
-      "blockHeight": 567890,
-      "confirmations": 7,
-    }
-    
-    $ # send out the new zone file to a Blockstack peer
-    $ stx -H https://stacks-node-api.stacks.co zonefile_push /tmp/zonefile.txt
-    [
-      "https://stacks-node-api.stacks.co"
-    ]
+```console
+$ # Tip: you can get your owner and payment keys from your 12-word backup phrase using the get_owner_keys and get_payment_key commands.
+$ export OWNER="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"
+$ export PAYMENT="bfeffdf57f29b0cc1fab9ea197bb1413da2561fe4b83e962c7f02fbbe2b1cd5401"
+$ # make a new zone file
+$ stx make_zonefile example.id ID-1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82 https://my.gaia.hub/hub > /tmp/zonefile.txt
 
+$ # update the name to reference this new zone file
+$ stx update example.id /tmp/zonefile.txt "$OWNER" "$PAYMENT"
+8e94a5b6647276727a343713d3213d587836e1322b1e38bc158406f5f8ebe3fd
 
+$ # check confirmations
+$ stx get_confirmations e41ce043ab64fd5a5fd382fba21acba8c1f46cbb1d7c08771ada858ce7d29eea
+{
+  "blockHeight": 567890,
+  "confirmations": 7,
+}
+
+$ # send out the new zone file to a Blockstack peer
+$ stx -H https://stacks-node-api.stacks.co zonefile_push /tmp/zonefile.txt
+[
+  "https://stacks-node-api.stacks.co"
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1433,24 +1475,24 @@ Look up the zone file and owner of a Blockstack ID.  Works with both on-chain an
 
 Example:
 
-    $ stx whois example.id
-    {
-      "address": "1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82",
-      "block_renewed_at": 567890,
-      "blockchain": "bitcoin",
-      "expire_block": 687010,
-      "grace_period": false,
-      "last_transaction_height": "567891",
-      "last_txid": "a564aa482ee43eb2bdfb016e01ea3b950bab0cfa39eace627d632e73c7c93e48",
-      "owner_script": "76a9146c1c2fc3cf74d900c51e9b5628205130d7b98ae488ac",
-      "renewal_deadline": 692010,
-      "resolver": null,
-      "status": "registered",
-      "zonefile": "$ORIGIN example.id\n$TTL 3600\n_http._tcp URI 10 1 \"https://gaia.blockstack.org/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json\"\n",
-      "zonefile_hash": "ae4ee8e7f30aa890468164e667e2c203266f726e"
-    }
-
-
+```console
+$ stx whois example.id
+{
+  "address": "1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82",
+  "block_renewed_at": 567890,
+  "blockchain": "bitcoin",
+  "expire_block": 687010,
+  "grace_period": false,
+  "last_transaction_height": "567891",
+  "last_txid": "a564aa482ee43eb2bdfb016e01ea3b950bab0cfa39eace627d632e73c7c93e48",
+  "owner_script": "76a9146c1c2fc3cf74d900c51e9b5628205130d7b98ae488ac",
+  "renewal_deadline": 692010,
+  "resolver": null,
+  "status": "registered",
+  "zonefile": "$ORIGIN example.id\n$TTL 3600\n_http._tcp URI 10 1 \"https://gaia.blockstack.org/hub/1ArdkA2oLaKnbNbLccBaFhEV4pYju8hJ82/profile.json\"\n",
+  "zonefile_hash": "ae4ee8e7f30aa890468164e667e2c203266f726e"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1464,12 +1506,12 @@ Push a zone file on disk to the Blockstack peer network.  The zone file must cor
 
 Example:
 
-    $ stx -H https://stacks-node-api.stacks.co zonefile_push /path/to/zonefile.txt
-    [
-      "https://stacks-node-api.stacks.co"
-    ]
-
-
+```console
+$ stx -H https://stacks-node-api.stacks.co zonefile_push /path/to/zonefile.txt
+[
+  "https://stacks-node-api.stacks.co"
+]
+```
 
 | Name | Type | Value |
 |-|-|-|
@@ -1483,32 +1525,35 @@ Creates a DID configuration for the given blockstack id and domain to create a l
 The DID configuration should be placed in the json file ".well_known/did_configuration"
 Example:
 
-    $ # Tip: you can get your owner keys from your 12-word backup phrase using the get_owner_keys command.
-    $ export PRIVATE_OWNER_KEY="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"
-    $ stx get_did_configuration public_profile_for_testing.id.blockstack helloblockstack.com PRIVATE_OWNER_KEY
-    {
-       "entries": [
-          {
-            "did": "did:stack:v0:SewTRvPZUEQGdr45QvEnVMGHZBhx3FT1Jj-0",
-            "jwt": "eyJ0eXAiOiJKV1QiL...."
-          }
-       ]
-    }
+```console
+$ # Tip: you can get your owner keys from your 12-word backup phrase using the get_owner_keys command.
+$ export PRIVATE_OWNER_KEY="6e50431b955fe73f079469b24f06480aee44e4519282686433195b3c4b5336ef01"
+$ stx get_did_configuration public_profile_for_testing.id.blockstack helloblockstack.com PRIVATE_OWNER_KEY
+{
+   "entries": [
+      {
+        "did": "did:stack:v0:SewTRvPZUEQGdr45QvEnVMGHZBhx3FT1Jj-0",
+        "jwt": "eyJ0eXAiOiJKV1QiL...."
+      }
+   ]
+}
+```
 
-The decoded content of the jwt above is 
-    {
-       "header": {
-          "typ": "JWT", "alg": "ES256K"
-       },
-       "payload": {
-           "iss": "did:stack:v0:SewTRvPZUEQGdr45QvEnVMGHZBhx3FT1Jj-0",
-           "domain": "helloblockstack.com",
-           "exp": "2020-12-07T13:05:28.375Z"
-       },
-       "signature": "NDY7ISzgAHKcZDvbxzTxQdVnf6xWMZ46w5vHcDpNx_1Fsyip0M6E6GMq_2YZ-gUcwmwlo8Ag9jgnfOkaBIFpoQ"
-    }
+The decoded content of the jwt above is
 
-
+```json
+{
+   "header": {
+      "typ": "JWT", "alg": "ES256K"
+   },
+   "payload": {
+       "iss": "did:stack:v0:SewTRvPZUEQGdr45QvEnVMGHZBhx3FT1Jj-0",
+       "domain": "helloblockstack.com",
+       "exp": "2020-12-07T13:05:28.375Z"
+   },
+   "signature": "NDY7ISzgAHKcZDvbxzTxQdVnf6xWMZ46w5vHcDpNx_1Fsyip0M6E6GMq_2YZ-gUcwmwlo8Ag9jgnfOkaBIFpoQ"
+}
+```
 
 | Name | Type | Value |
 |-|-|-|

--- a/docs/smart-contracts/clarinet.md
+++ b/docs/smart-contracts/clarinet.md
@@ -88,7 +88,6 @@ located in the `settings` directory control the Clarinet environment. For exampl
 definitions for wallets in the local REPL environment, and their starting balances (in STX).
 
 ```toml
-...
 [accounts.deployer]
 mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"
 balance = 1_000_000
@@ -100,7 +99,6 @@ balance = 1_000_000
 [accounts.wallet_2]
 mnemonic = "arrange scale orient half ugly kid bike twin magnet joke hurt fiber ethics super receive version wreck media fluid much abstract reward street alter"
 balance = 1_000_000
-...
 ```
 
 You can create a new contract in the project with the command:
@@ -213,7 +211,6 @@ unit tests as you develop the contract.
 An example unit test for the `echo-number` function is provided below:
 
 ```ts
-...
 Clarinet.test({
   name: 'the echo-number function returns the input value ok',
   async fn(chain: Chain, accounts: Map<string, Account>) {

--- a/docs/stacks-2.1-upgrades.md
+++ b/docs/stacks-2.1-upgrades.md
@@ -67,7 +67,6 @@ Find the section [devnet] with the following settings.
 [devnet]
 disable_stacks_explorer = false
 disable_stacks_api = false
-# ...
 ```
 
 Add a new setting, `enable_next_features = true,` and keep the remaining settings as-is.
@@ -79,7 +78,6 @@ The updated Devnet.toml looks like this:
 enable_next_features = true
 disable_stacks_explorer = false
 disable_stacks_api = false
-# ...
 ```
 
 Spin up a local Devnet network using the command:
@@ -104,7 +102,6 @@ These block heights can be customized using the settings in the devnet.toml:
 
 ```toml
 [devnet]
-# ...
 epoch_2_05 = 102
 epoch_2_1 = 106
 ```

--- a/docs/stacks-2.1-upgrades.md
+++ b/docs/stacks-2.1-upgrades.md
@@ -63,28 +63,30 @@ After installing the latest version of Clarinet, navigate to your project direct
 
 Find the section [devnet] with the following settings.
 
-```
+```toml
 [devnet]
 disable_stacks_explorer = false
 disable_stacks_api = false
-...
+# ...
 ```
 
 Add a new setting, `enable_next_features = true,` and keep the remaining settings as-is.
 
 The updated Devnet.toml looks like this:
 
-```
+```toml
 [devnet]
 enable_next_features = true
 disable_stacks_explorer = false
 disable_stacks_api = false
-...
+# ...
 ```
 
 Spin up a local Devnet network using the command:
 
-`clarinet integrate`
+```sh
+clarinet integrate
+```
 
 If you have any trouble with the above command, refer to the [troubleshooting guide](https://github.com/hirosystems/clarinet/blob/main/docs/troubleshooting.md) or report an issue [here](https://github.com/hirosystems/clarinet/issues).
 
@@ -100,9 +102,9 @@ As shown in the below screenshot, the epoch changes are indicated in the _Transa
 
 These block heights can be customized using the settings in the devnet.toml:
 
-```
+```toml
 [devnet]
-...
+# ...
 epoch_2_05 = 102
 epoch_2_1 = 106
 ```
@@ -118,30 +120,30 @@ The following updates for the API endpoints are for the Stacks 2.1 upgrade.
 
 This section explains the new property returned with the following existing endpoints.
 
-The endpoints `/extended/v1/tx/<txid>` and `/extended/v1/contract/<contract-id>` now return a new property, `clarity_version.`
+The endpoints `/extended/v1/tx/<txid>` and `/extended/v1/contract/<contract-id>` now return a new property, `clarity_version`.
 
 The sample response with the new property is shown below:
 
-```
+```json
 {
   "tx_id": "0x33c573f5ed06f1feecaa4a9df0225e109416dbba9792abb0cd94869bbad4a88a",
   "canonical": true,
   "contract_id": "ST000000000000000000002AMW42H.pox-2",
   "block_height": 2,
-  "clarity_version": 2, <-- New
+  "clarity_version": 2, # <-- New
   "source_code": ";; PoX testnet constants\n;; Min/max number of reward cycles uSTX can be locked for..."
 }
 ```
 
 A sample response for a regular (non-versioned) smart contract transaction with Clarity version null is shown below:
 
-```
+```json
 {
   "tx_id": "0x55bb3a37f9b2e8c58905c95099d5fc21aa47d073a918f3b30cc5abe4e3be44c6",
   "canonical": true,
   "contract_id": "ST000000000000000000002AMW42H.bns",
   "block_height": 1,
-  "clarity_version": null, <-- New
+  "clarity_version": null, # <-- New
   "source_code": ";;;; Errors\n(define-constant ERR_PANIC 0)..."
 }
 ```
@@ -195,7 +197,7 @@ Previous `@stacks/stacking` releases will automatically switch to the new PoX co
 
 However, if you want to use the new methods detailed above, you need to update to `@stacks/stacking` to a version >=`6.0.0`. The updated release will also always prefer PoX-2 if possible. Use the following command to update the version.
 
-```
+```sh
 npm install @stacks/stacking@^6.0.0
 ```
 

--- a/docs/subnets/event-dispatcher.md
+++ b/docs/subnets/event-dispatcher.md
@@ -12,13 +12,11 @@ The `stacks-node` supports a configurable event observer interface.
 This is enabled by adding an entry to the node's `config.toml` file:
 
 ```toml
-...
 [[events_observer]]
 endpoint = "listener:3700"
 events_keys = [
   "*"
 ]
-...
 ```
 
 The `stacks-node` will then execute HTTP POSTs to the configured


### PR DESCRIPTION
## Description

Use Markdown code blocks instead inline code formatting. See #474 for more details

Also, this PR adds syntax highlighting to several existing code blocks. Note that console output can be highlighted this way:

````markdown
```console
$ echo 'Hello world!'                                                                                                                                                                                                                                                                                                                                                                                                             
Hello world!
```
````

Which renders as:
```console
$ echo 'Hello world!'                                                                                                                                                                                                                                                                                                                                                                                                             
Hello world!
```

## Applicable issues
- fixes #474


## Checklist

- [ ] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [ ] [Style guide](https://developers.google.com/style) was reviewed and applied
- [ ] Clear code samples were provided
- [ ] People were tagged for review
