### PR TITLE
[docathon] fix Docusaurus start process

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,7 +86,6 @@ module.exports = {
           'how-to-run-stacks-blockchain-api-docker.md',
           'how-to-run-testnet-node.md',
           'how-to-upgrade-stacks-blockchain-api.md',
-          'how-to-use-docker-with-Stacks-blockchain-api.md',
         ],
       },
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -97,7 +97,6 @@ module.exports = {
             'stacks-blockchain-api/how-to-guides/how-to-run-mainnet-node',
             'stacks-blockchain-api/how-to-guides/how-to-run-testnet-node',
             'stacks-blockchain-api/how-to-guides/how-to-handle-errors',
-            'stacks-blockchain-api/how-to-guides/how-to-use-docker-with-Stacks-blockchain-api',
             'stacks-blockchain-api/how-to-guides/how-to-run-stacks-blockchain-api-docker',
             'stacks-blockchain-api/how-to-guides/how-to-deploy-service-dependencies',
             'stacks-blockchain-api/how-to-guides/how-to-upgrade-stacks-blockchain-api',


### PR DESCRIPTION
This PR fix Docusaurus start process.

A documentation referenced by Docusaurus was removed in the `stacks-blockchain-api` repo. Updating it.