### PR TITLE
streamline page footer information

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -557,10 +557,6 @@ module.exports = {
             title: 'Hiro Developers',
             items: [
               {
-                label: 'Stacks Blockchain API',
-                to: '/api',
-              },
-              {
                 label: 'Tutorials',
                 to: '/tutorials',
               },


### PR DESCRIPTION
This PR removes the link to the Stacks blockchain API on the page footer.

The link to the Stacks blockchain API on the page footer is redundant with the link in the `Recipients` dropdown. And also other APIs doesn't have links on the page footer.