### PR TITLE
fix: add missing backticks

### DIFF
--- a/docs/hacks/build-a-friend-tech-clone.mdx
+++ b/docs/hacks/build-a-friend-tech-clone.mdx
@@ -237,6 +237,7 @@ If you are here for the Hiro Hacks prizes (see the [overview page](https://docs.
 (define-read-only (get-keys-supply (subject principal))
   ;; Return the keysSupply for the given subject
 )
+```
 
 <span className="inline-flex items-center rounded-md bg-green-50 dark:bg-green-400/10 px-2 py-1 mb-2 text-xs font-medium text-green-700 dark:text-green-400 ring-1 ring-inset ring-green-600/10 dark:ring-green-400/20">
   Starter
@@ -263,6 +264,7 @@ If you are here for the Hiro Hacks prizes (see the [overview page](https://docs.
 ;; Change the fee values as you wish
 (define-data-var protocolFeePercent uint u200) ;; or subjectFeePercent
 (define-data-var protocolFeeDestination principal tx-sender)
+```
 
 <span className="inline-flex items-center rounded-md bg-yellow-50 dark:bg-yellow-400/10 px-2 py-1 mb-2 text-xs font-medium text-yellow-700 dark:text-yellow-400 ring-1 ring-inset ring-yellow-600/10 dark:ring-yellow-400/20">
   Intermediate


### PR DESCRIPTION
The formatting is messed up because there are some missing backticks after code sections.