### PR TITLE
Update legacy URLs

### DIFF
--- a/docs/build-apps/integrate-stacking.md
+++ b/docs/build-apps/integrate-stacking.md
@@ -287,7 +287,7 @@ More details on the lifecycle of transactions can be found in the [transactions 
 Alternatively to the polling, the Stacks Blockchain API client library offers WebSockets. WebSockets can be used to subscribe to specific updates, like transaction status changes. Here is an example:
 
 ```js
-const client = await connectWebSocketClient('ws://stacks-node-api.blockstack.org/');
+const client = await connectWebSocketClient('ws://api.hiro.so/');
 
 // note: txId should be defined previously
 const sub = await client.subscribeAddressTransactions(txId, event => {

--- a/docs/get-started/command-line-interface.md
+++ b/docs/get-started/command-line-interface.md
@@ -31,7 +31,7 @@ For account usage, that means addresses generated will _only_ be available for t
 
 :::
 
-Using the `-t` flag causes the CLI to connect to the testnet node at `http://api.hiro.so:20443`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
+Using the `-t` flag causes the CLI to connect to the testnet at `https://api.testnet.hiro.so`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
 
 ```sh
 stx <command> -I "http://localhost:20443"

--- a/docs/get-started/command-line-interface.md
+++ b/docs/get-started/command-line-interface.md
@@ -31,7 +31,7 @@ For account usage, that means addresses generated will _only_ be available for t
 
 :::
 
-Using the `-t` flag causes the CLI to connect to the testnet node at `http://stacks-node-api.blockstack.org:20443`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
+Using the `-t` flag causes the CLI to connect to the testnet node at `http://api.hiro.so:20443`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
 
 ```sh
 stx <command> -I "http://localhost:20443"

--- a/docs/get-started/stacks-blockchain-api.md
+++ b/docs/get-started/stacks-blockchain-api.md
@@ -243,7 +243,7 @@ import { uintCV, UIntCV, cvToHex, hexToCV, ClarityType } from '@stacks/transacti
 
   const principal: string = 'ST000000000000000000002AMW42H';
 
-  // use most recent from: https://stacks-node-api.<mainnet/testnet>.stacks.co/v2/pox
+  // use most recent from: https://api.<mainnet/testnet>.hiro.so/v2/pox
   const rewardCycle: UIntCV = uintCV(22);
 
   // call a read-only function
@@ -318,7 +318,7 @@ The API allows querying the most recently streamed microblocks:
 
 ```bash
 # for mainnet, remove `.testnet`
-curl 'https://stacks-node-api-microblocks.testnet.stacks.co/extended/v1/microblock'
+curl 'https://api.testnet.hiro.so/extended/v1/microblock'
 ```
 
 ```json
@@ -352,7 +352,7 @@ API provides an endpoint to make nonce handling simpler:
 ```bash
 # for mainnet, remove `.testnet`
 # replace <principal> with your STX address
-curl 'https://stacks-node-api-microblocks.testnet.stacks.co/extended/v1/address/<principal>/nonces'
+curl 'https://api.testnet.hiro.so/extended/v1/address/<principal>/nonces'
 ```
 
 ```json

--- a/docs/get-started/stacks-blockchain-api.md
+++ b/docs/get-started/stacks-blockchain-api.md
@@ -139,7 +139,7 @@ The WebSocket components enabled you to subscribe to specific updates, enabling 
 ```js
 import { connectWebSocketClient } from '@stacks/blockchain-api-client';
 
-const client = await connectWebSocketClient('ws://stacks-node-api.blockstack.org/');
+const client = await connectWebSocketClient('ws://api.hiro.so/');
 
 const sub = await client.subscribeAddressTransactions(contractCall.txId, event => {
   console.log(event);

--- a/docs/stacks-blockchain-api/how-to-guides/how-to-install-stacks-cli.md
+++ b/docs/stacks-blockchain-api/how-to-guides/how-to-install-stacks-cli.md
@@ -30,7 +30,7 @@ For account usage, that means addresses generated will _only_ be available for t
 
 :::
 
-Using the `-t` flag causes the CLI to connect to the testnet node at `http://stacks-node-api.blockstack.org:20443`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
+Using the `-t` flag causes the CLI to connect to the testnet node at `http://api.hiro.so:20443`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
 
 ```sh
 stx <command> -I "http://localhost:20443"

--- a/docs/stacks-blockchain-api/how-to-guides/how-to-install-stacks-cli.md
+++ b/docs/stacks-blockchain-api/how-to-guides/how-to-install-stacks-cli.md
@@ -30,7 +30,7 @@ For account usage, that means addresses generated will _only_ be available for t
 
 :::
 
-Using the `-t` flag causes the CLI to connect to the testnet node at `http://api.hiro.so:20443`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
+Using the `-t` flag causes the CLI to connect to the testnet at `https://api.testnet.hiro.so`. To specify a node to connect to, add the `-I` flag followed by the URL of the node:
 
 ```sh
 stx <command> -I "http://localhost:20443"

--- a/docs/stacks-blockchain-api/how-to-guides/how-to-query-stacks2.0-blockchain.md
+++ b/docs/stacks-blockchain-api/how-to-guides/how-to-query-stacks2.0-blockchain.md
@@ -136,7 +136,7 @@ The WebSocket components enabled you to subscribe to specific updates, enabling 
 ```js
 import { connectWebSocketClient } from '@stacks/blockchain-api-client';
 
-const client = await connectWebSocketClient('ws://stacks-node-api.blockstack.org/');
+const client = await connectWebSocketClient('ws://api.hiro.so/');
 
 const sub = await client.subscribeAddressTransactions(contractCall.txId, event => {
   console.log(event);

--- a/docs/stacks-blockchain-api/index.md
+++ b/docs/stacks-blockchain-api/index.md
@@ -134,7 +134,7 @@ The WebSocket components enable you to subscribe to specific updates, providing 
 
 ```js
 import { connectWebSocketClient } from '@stacks/blockchain-api-client';
-const client = await connectWebSocketClient('ws://stacks-node-api.blockstack.org/');
+const client = await connectWebSocketClient('ws://api.hiro.so/');
 const sub = await client.subscribeAddressTransactions(contractCall.txId, event => {
   console.log(event);
 });

--- a/docs/stacks.js/guides/how-to-integrate-stacking-delegation.md
+++ b/docs/stacks.js/guides/how-to-integrate-stacking-delegation.md
@@ -34,7 +34,7 @@ stacks make_keychain -t > delegator.json
 You can use the faucet to obtain testnet STX tokens for the test account. Replace `<stxAddress>` below with your address:
 
 ```sh
-curl -XPOST "https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
+curl -XPOST "https://api.testnet.hiro.so/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
 ```
 
 ## Step 1: Integrate libraries

--- a/docs/stacks.js/guides/how-to-integrate-stacking.md
+++ b/docs/stacks.js/guides/how-to-integrate-stacking.md
@@ -157,7 +157,7 @@ const hasMinStxAmount = await client.hasMinimumStx();
 For testing purposes, you can use the faucet to obtain testnet STX tokens. Replace `<stxAddress>` below with your address:
 
 ```shell
-curl -XPOST "https://stacks-node-api.testnet.stacks.co/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
+curl -XPOST "https://api.testnet.hiro.so/extended/v1/faucets/stx?address=<stxAddress>&stacking=true"
 ```
 
 You'll have to wait a few minutes for the transaction to complete.
@@ -332,5 +332,5 @@ As an example, if you want to get the rewards paid to `btcAddress`, you can make
 
 ```shell
 # for mainnet, replace `testnet` with `mainnet`
-curl 'https://stacks-node-api.testnet.stacks.co/extended/v1/burnchain/rewards/<btcAddress>'
+curl 'https://api.testnet.hiro.so/extended/v1/burnchain/rewards/<btcAddress>'
 ```

--- a/docs/stacks.js/guides/how-to-integrate-stacking.md
+++ b/docs/stacks.js/guides/how-to-integrate-stacking.md
@@ -274,7 +274,7 @@ More details on the lifecycle of transactions can be found in the [transactions 
 Alternatively to the polling, the Stacks Blockchain API client library offers WebSockets. WebSockets can be used to subscribe to specific updates, like transaction status changes. Here is an example:
 
 ```js
-const client = await connectWebSocketClient('ws://stacks-node-api.blockstack.org/');
+const client = await connectWebSocketClient('ws://api.hiro.so/');
 
 // note: txId should be defined previously
 const sub = await client.subscribeAddressTransactions(txId, event => {


### PR DESCRIPTION
Update legacy URLs.

## Description

- chore: update legacy blockstack.org URLs.
- chore: update more URLs.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] People were tagged for review
