### PR TITLE
Add info on Ordinals API for testnet

### DIFF
--- a/docs/ordinals-api/index.md
+++ b/docs/ordinals-api/index.md
@@ -37,3 +37,7 @@ The following rate-limits (in requests per minute, or RPM) are applicable for al
 These new rate limits help us ensure fair usage of Hiro APIs and provide the best possible service as our community of developers and applications grow and scale.
 
 Please [complete this form](https://survey.hiro.so/hiroapi) to apply for an API key.
+
+# Testnet for Ordinals API
+
+A testnet version of the Ordinals API is unavailable, as the vast majority of activity occurs on Bitcoin mainnet. Exploration or testing with the Hiro Ordinals API is permitted, as long as it adheres to our [Terms of Use](https://www.hiro.so/terms)https://www.hiro.so/terms.


### PR DESCRIPTION
Had a few people make this request, could be worthwhile mentioning in the doc that there's no testnet Ord API. My justification could be incorrect, please feel free to modify.