### PR TITLE
fix title in api-keys.md

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -5,15 +5,15 @@ title: API Keys
 
 Developers have open access to Hiro's APIs, without the use of an API key, subjects to Hiro's [rate limit policy](https://docs.hiro.so/rate-limiting). For developers who need access beyond these rate limits, we provide API keys.
 
-# What Is an API Key?
+## What Is an API Key?
 
 API keys are alpha-numeric codes that identify and authenticate an application or developer. You can use API keys to control access to your API calls.
 
-# How to Get an API Key?
+## How to Get an API Key?
 
 If you're interested in obtaining an API key, you can generate a free key in the [Hiro Platform](https://platform.hiro.so/).
 
-# Steps to Use an API Key
+## Steps to Use an API Key
 
 Follow these steps to interact with the API using your API key:
 

--- a/docs/stacks-2.1-upgrades.md
+++ b/docs/stacks-2.1-upgrades.md
@@ -12,7 +12,7 @@ In this article, you will learn about Stacks 2.05 to 2.1 migration and how the H
 
 ## What is PoX-2?
 
-[Proof-of-transfer (PoX)](https://docs.stacks.co/docs/understand-stacks/proof-of-transfer) is a consensus mechanism in modern blockchains. In Stacks 2.05 or earlier versions, this consensus mechanism uses the `.pox` ([boot/pox.clar](https://explorer.hiro.so/txid/SP000000000000000000002Q6VF78.pox?chain=mainnet&_gl=1*6fljeg*_ga*MTY3NTgyOTg2OS4xNjY2MjA3NDM3*_ga_NB2VBT0KY2*MTY3MDk1ODcyNS4xMTEuMC4xNjcwOTU4NzI1LjAuMC4w), aka PoX-1) boot smart contract. With the Stacks 2.1 upgrade, the new fork is updated to `.pox-2` ([boot/pox-2.clar](https://github.com/stacks-network/stacks-core/blob/1d8920ed68be2d1982b91f729522ff0c6e00572f/stackslib/src/chainstate/stacks/boot/pox-2.clar#L1022), aka PoX-2).
+[Proof-of-transfer (PoX)](https://docs.stacks.co/docs/understand-stacks/proof-of-transfer) is a consensus mechanism in modern blockchains. In Stacks 2.05 or earlier versions, this consensus mechanism uses the `.pox` ([boot/pox.clar](https://explorer.hiro.so/txid/SP000000000000000000002Q6VF78.pox?chain=mainnet&_gl=1*6fljeg*_ga*MTY3NTgyOTg2OS4xNjY2MjA3NDM3*_ga_NB2VBT0KY2*MTY3MDk1ODcyNS4xMTEuMC4xNjcwOTU4NzI1LjAuMC4w), aka PoX-1) boot smart contract. With the Stacks 2.1 upgrade, the new fork is updated to `.pox-2` ([boot/pox-2.clar](https://github.com/stacks-network/stacks-core/blob/1d8920ed68be2d1982b91f729522ff0c6e00572f/stackslib/src/chainstate/stacks/boot/pox-2.clar), aka PoX-2).
 
 ### PoX-2 periods
 


### PR DESCRIPTION
## Description

Other headers were overriding the default title in `api-keys.md` so I changed those to be `h2`