### PR TITLE
update ordinals api routing

### DIFF
--- a/sidebars/root.js
+++ b/sidebars/root.js
@@ -40,7 +40,7 @@ module.exports = [
     type: 'category',
     label: 'Ordinals API',
     type: 'link',
-    href: '/ordinals-api',
+    href: '/ordinals',
   },
   {
     type: 'category',

--- a/src/components/_content.ts
+++ b/src/components/_content.ts
@@ -44,7 +44,7 @@ export default {
       {
         title: 'Ordinals API',
         text: 'Ordinals API is a REST-based service that indexes Bitcoin inscriptions based on Ordinal theory. The API supports Auto-scaling and Etag caching.',
-        href: '/ordinals-api',
+        href: '/ordinals',
         image: {
           src: '/img/landing/ordinals-api.png',
           alt: 'Ordinals API',


### PR DESCRIPTION
## What does this PR do?

The Ordinals API overview page creates some confusion on where to go to next, so this PR routes both the *Popular Section* reference and *sidebar* links to the overview page generated by OpenAPI.

- [x] update routes for ordinals-api section