### PR TITLE
updates for nakamoto mainnet instantiation

### DIFF
--- a/docs/nakamoto/clarinet.mdx
+++ b/docs/nakamoto/clarinet.mdx
@@ -34,14 +34,14 @@ Start the Devnet with `clarinet devnet start`.
 ## Deploy contracts on the Nakamoto Testnet
 
 A Nakamoto testnet is available and running in Epoch 2.5. Clarinet can be used to deploy contracts
-on this testnet (available at https://api.nakamoto.testnet.hiro.so).
+on testnet.
 
 In a Clarinet project, the `settings/Testnet.toml` file can be updated like so:
 
 ```toml
 [network]
 name = "testnet"
-stacks_node_rpc_address = "https://api.nakamoto.testnet.hiro.so"
+stacks_node_rpc_address = "https://api.testnet.hiro.so"
 deployment_fee_rate = 10
 
 [accounts.deployer]

--- a/docs/nakamoto/explorer.mdx
+++ b/docs/nakamoto/explorer.mdx
@@ -13,7 +13,7 @@ The Stacks Explorer now features a new way to display blocks, aligning with the 
 
 ### Tailored Viewing Experience
 
-This new view is available on [Nakamoto Testnet](https://explorer.hiro.so/?chain=testnet&api=https://api.nakamoto.testnet.hiro.so), accessible via the Network dropdown.
+This new view is now live on both [Testnet](https://explorer.hiro.so/?chain=testnet) and [Mainnet](https://explorer.hiro.so/?chain=mainnet), accessible via the Network dropdown.
 
 #### Two Distinctive Display Modes
 

--- a/docs/nakamoto/index.mdx
+++ b/docs/nakamoto/index.mdx
@@ -17,7 +17,7 @@ The Stacks Explorer now features a new way to display blocks, aligning with the 
 
 ### Tailored Viewing Experience
 
-This new view is available on [Nakamoto Testnet](https://explorer.hiro.so/?chain=testnet&api=https://api.nakamoto.testnet.hiro.so), accessible via the Network dropdown.
+This new view is now live on both [Testnet](https://explorer.hiro.so/?chain=testnet) and [Mainnet](https://explorer.hiro.so/?chain=mainnet), accessible via the Network dropdown.
 
 #### Two Distinctive Display Modes
 
@@ -66,10 +66,6 @@ Make sure to install [Clarinet 2.4.0](https://github.com/hirosystems/clarinet/re
 > **_NOTE:_**
 >
 > The `/extended/v2/*` endpoints represent the modern API that is being continually expanded to support the Nakamoto upgrade. We encourage developers to use v2 endpoints for new developments. Be aware that `/extended/v1/*` are the older set of endpoints. Though they continue to function alongside v2, be advised that they will be deprecated in the coming months.
-
-### New Testnet URL
-
-`https://api.nakamoto.testnet.hiro.so`
 
 ### Nakamoto endpoints
 

--- a/docs/nakamoto/stacks-api.mdx
+++ b/docs/nakamoto/stacks-api.mdx
@@ -9,10 +9,6 @@ custom_edit_url: null
 >
 > The `/extended/v2/*` endpoints represent the modern API that is being continually expanded to support the Nakamoto upgrade. We encourage developers to use v2 endpoints for new developments. Be aware that `/extended/v1/*` are the older set of endpoints. Though they continue to function alongside v2, be advised that they will be deprecated in the coming months.
 
-### New Testnet URL
-
-`https://api.nakamoto.testnet.hiro.so`
-
 ### Nakamoto endpoints
 
 The Stacks Blockchain API has a series of new endpoints to support the upcoming Nakamoto upgrade:

--- a/docs/nakamoto/stacks-js.mdx
+++ b/docs/nakamoto/stacks-js.mdx
@@ -17,13 +17,13 @@ The StackingClient in `@stacks/stacking` was updated to match the latest pox-4 c
 
 ### Nakamoto Network
 
-To test using the Nakamoto testnet, you can use the `StacksTestnet` network with a custom URL. The Nakamoto testnet is being hosted at https://api.nakamoto.testnet.hiro.so. Use this URL like this:
+To test using the Nakamoto testnet, you can use the `StacksTestnet` network with a custom URL. The Nakamoto testnet is being hosted at https://api.testnet.hiro.so. Use this URL like this:
 
 ```tsx
 import { StacksTestnet } from '@stacks/network';
 
 const network = new StacksTestnet({
-  url: 'https://api.nakamoto.testnet.hiro.so',
+  url: 'https://api.testnet.hiro.so',
 });
 ```
 

--- a/src/components/_content.ts
+++ b/src/components/_content.ts
@@ -34,7 +34,7 @@ export default {
     type: 'info',
     from: '2024-03-15',
     to: '2024-04-20',
-    text: ['The Nakamoto upgrade is now live on Testnet! See a list of Hiro product changes here.'],
+    text: ['The Nakamoto upgrade is now live on Mainnet! See a list of Hiro product changes here.'],
     cta: 'View Changes',
     ctaLink: '/nakamoto',
     relativeUrl: true,


### PR DESCRIPTION
## What does this PR do?

- [ ] Update banner copy for `mainnet`
- [ ] Remove new testnet url and point to default `api.testnet.hiro.so`
- [ ] Update explorer sections to notify the new views are live on both `testnet` and `mainnet`
