### PR TITLE
update banner message

### DIFF
--- a/src/components/_content.ts
+++ b/src/components/_content.ts
@@ -24,9 +24,9 @@ export default {
   topBanner: {
     type: 'info',
     from: '2024-04-22',
-    to: '2024-05-22',
-    text: ['The Nakamoto upgrade is now live on Mainnet'],
-    cta: 'View changes to Hiro Products here',
+    to: '2024-08-01',
+    text: ["The Nakamoto upgrade is now live on mainnet and currently in the 'Instantiation' phase"],
+    cta: 'View updates to Hiro Products here',
     ctaLink: '/nakamoto',
     relativeUrl: true,
   },


### PR DESCRIPTION
## What does this PR do?

- [x] update the banner message to be more clear about what phase the nakamoto upgrade is currently in

<img width="1228" alt="Screenshot 2024-05-06 at 9 17 36 AM" src="https://github.com/hirosystems/docs/assets/3207017/0621ca07-fd7c-4987-9a83-640fa16de51d">
