### PR TITLE
update endpoint for retrieving stacking pool members

### DIFF
--- a/content/docs/stacks/api/stacking-pool/members.mdx
+++ b/content/docs/stacks/api/stacking-pool/members.mdx
@@ -23,7 +23,7 @@ import { InlineCode } from '@/components/inline-code';
   <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
     GET
   </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/beta/stacking/{pool_principal}/delegations`}</p>
+  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/pox3/{pool_principal}/delegations`}</p>
 </h2>
 
 Retrieves the list of stacking pool members for a given delegator principal.
@@ -85,7 +85,7 @@ Number of items to skip
 <APIExample>
 
 ```bash title="Terminal"
-curl -X GET "https://api.mainnet.hiro.so/extended/beta/stacking/string/delegations"
+curl -X GET "https://api.mainnet.hiro.so/extended/v1/pox3/SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP/delegations"
 ```
 
 <Tabs items={["200"]}>


### PR DESCRIPTION
### What does this PR do?

In reference to https://github.com/hirosystems/docs/issues/675, there is a bad usage example for retrieving the stacking pool members. However, when investigating I noticed that the current `/extended/beta/stacking` endpoint redirects to `/extended/v1/pox3`.

I've updated the reference to reflect this, but need to confirm this is an accurate change.

cc @rafaelcr 