### PR TITLE
Chore/openapi components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules
 .next
 bun.lockb
 openapi
-public/.DS_Store
+.DS_Store
+**/.DS_Store

--- a/content/docs/ordinals/api/brc20/get-brc20-activity.mdx
+++ b/content/docs/ordinals/api/brc20/get-brc20-activity.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/brc-20/activity`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/brc-20/activity"}>
 
 Retrieves BRC-20 activity filtered by ticker, address, operation, or at a specific block height.
 
@@ -70,7 +63,7 @@ Results per page
 | :---------- | :--------------- |
 | `200`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/brc20/get-brc20-balances.mdx
+++ b/content/docs/ordinals/api/brc20/get-brc20-balances.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/brc-20/balances/{address}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/brc-20/balances/{address}"}>
 
 Retrieves BRC-20 token balances for a Bitcoin address.
 
@@ -68,7 +61,7 @@ Bitcoin address
 | :---------- | :--------------- |
 | `200`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/brc20/get-brc20-token-details.mdx
+++ b/content/docs/ordinals/api/brc20/get-brc20-token-details.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/brc-20/tokens/{ticker}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/brc-20/tokens/{ticker}"}>
 
 Retrieves information for a BRC-20 token, including supply and holders.
 
@@ -35,7 +28,7 @@ Retrieves information for a BRC-20 token, including supply and holders.
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/brc20/get-brc20-token-holders.mdx
+++ b/content/docs/ordinals/api/brc20/get-brc20-token-holders.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/brc-20/tokens/{ticker}/holders`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/brc-20/tokens/{ticker}/holders"}>
 
 Retrieves a list of holders and their balances for a specified BRC-20 token.
 
@@ -55,7 +48,7 @@ Results per page
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/brc20/get-brc20-tokens.mdx
+++ b/content/docs/ordinals/api/brc20/get-brc20-tokens.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/brc-20/tokens`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/brc-20/tokens"}>
 
 Retrieves information for BRC-20 tokens.
 
@@ -58,7 +51,7 @@ Results per page
 | :---------- | :--------------- |
 | `200`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/info/status.mdx
+++ b/content/docs/ordinals/api/info/status.mdx
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/"}>
 
 Displays the status of the Ordinals API.
 
@@ -28,7 +21,7 @@ Displays the status of the Ordinals API.
 | :---------- | :--------------- |
 | `200`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/inscriptions/get-inscription-content.mdx
+++ b/content/docs/ordinals/api/inscriptions/get-inscription-content.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/inscriptions/{id}/content`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/inscriptions/{id}/content"}>
 
 Retrieves the content of a single inscription.
 
@@ -37,7 +30,7 @@ Inscription unique identifier (number or ID)
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/inscriptions/get-inscription-transfers.mdx
+++ b/content/docs/ordinals/api/inscriptions/get-inscription-transfers.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/inscriptions/{id}/transfers`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/inscriptions/{id}/transfers"}>
 
 Retrieves all transfers for a single inscription.
 
@@ -57,7 +50,7 @@ Inscription unique identifier (number or ID)
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/inscriptions/get-inscription.mdx
+++ b/content/docs/ordinals/api/inscriptions/get-inscription.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/inscriptions/{id}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/inscriptions/{id}"}>
 
 Retrieves a single inscription.
 
@@ -37,7 +30,7 @@ Inscription unique identifier (number or ID)
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/inscriptions/get-inscriptions.mdx
+++ b/content/docs/ordinals/api/inscriptions/get-inscriptions.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/inscriptions`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/inscriptions"}>
 
 Retrieves a list of inscriptions with options to filter and sort results.
 
@@ -195,7 +188,7 @@ Results order
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/inscriptions/get-transfers-per-block.mdx
+++ b/content/docs/ordinals/api/inscriptions/get-transfers-per-block.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/inscriptions/transfers`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/inscriptions/transfers"}>
 
 Retrieves a list of inscription transfers that ocurred at a specific Bitcoin block.
 
@@ -55,7 +48,7 @@ Results per page
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/satoshis/get-satoshi-inscriptions.mdx
+++ b/content/docs/ordinals/api/satoshis/get-satoshi-inscriptions.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/sats/{ordinal}/inscriptions`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/sats/{ordinal}/inscriptions"}>
 
 Retrieves all inscriptions associated with a single satoshi.
 
@@ -59,7 +52,7 @@ Ordinal number that uniquely identifies a satoshi
 | `200`       | Default response |
 | `400`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/satoshis/get-satoshi.mdx
+++ b/content/docs/ordinals/api/satoshis/get-satoshi.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/sats/{ordinal}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/sats/{ordinal}"}>
 
 Retrieves ordinal information for a single satoshi.
 
@@ -39,7 +32,7 @@ Ordinal number that uniquely identifies a satoshi
 | `200`       | Default response |
 | `400`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/ordinals/api/statistics/get-stats-inscription-count.mdx
+++ b/content/docs/ordinals/api/statistics/get-stats-inscription-count.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from "@/components/layout"
-import { Property } from "fumadocs-ui/components/api"
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from "fumadocs-ui/components/tabs"
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion"
 
 <API>
 
-<div className="flex-1">
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/ordinals/v1/stats/inscriptions`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/ordinals/v1/stats/inscriptions"}>
 
 Retrieves statistics on the number of inscriptions revealed per block.
 
@@ -47,7 +40,7 @@ Bitcoin block height
 | `200`       | Default response |
 | `404`       | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/assets.mdx
+++ b/content/docs/stacks/api/accounts/assets.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/assets`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/assets"}>
 
 Retrieves a list of all asset events associated with an account or a contract identifier. This includes transfers and mints.
 
@@ -78,7 +71,7 @@ Returned data representing the state at that point in time, rather than the curr
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/balances.mdx
+++ b/content/docs/stacks/api/accounts/balances.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/balances`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/balances"}>
 
 Retrieves total account balance information for a given address or contract identifier. This includes the balances of STX tokens, fungible tokens and non-fungible tokens.
 
@@ -62,7 +55,7 @@ Returned data representing the state up until that point in time, rather than th
 |:------------|:--------------|
 | `200`       | Success       |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/inbound-stx-transfers.mdx
+++ b/content/docs/stacks/api/accounts/inbound-stx-transfers.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/stx_inbound`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/stx_inbound"}>
 
 Retrieves a list of STX transfers with memos to the given principal.
 
@@ -84,7 +77,7 @@ Returned data representing the state up until that point in time, rather than th
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/info.mdx
+++ b/content/docs/stacks/api/accounts/info.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}"}>
 
 Retrieves the account data for a given account or contract identifier, where the balance is the hex encoding of a unsigned 128-bit integer (big-endian), the nonce is an unsigned 64-bit integer, and the proofs are provided as hex strings.
 
@@ -59,7 +52,7 @@ The Stacks chain tip to query from
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/latest-nonce.mdx
+++ b/content/docs/stacks/api/accounts/latest-nonce.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -15,16 +15,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <Root>
 
-<API>
-
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/nonces`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/nonces"}>
 
 Retrieves the latest nonce values used by an account by inspecting the mempool and anchored transactions.
 
@@ -60,7 +51,7 @@ Optionally get the nonce at a given block hash. Note: use either of the query pa
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 
@@ -130,7 +121,5 @@ export interface AddressNonces {
 </Tabs>
 
 </APIExample>
-
-</API>
 
 </Root>

--- a/content/docs/stacks/api/accounts/nft-events.mdx
+++ b/content/docs/stacks/api/accounts/nft-events.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/nft_events`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/nft_events"}>
 
 **NOTE:** This endpoint is <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> in favor of [Get nft holdings](/stacks/api/non-fungible-tokens/holdings).
 
@@ -79,7 +71,7 @@ Returned data representing the state up until that point in time, rather than th
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/stx-balances.mdx
+++ b/content/docs/stacks/api/accounts/stx-balances.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/stx`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/stx"}>
 
 Retrieves STX token balance for a given address or contract identifier.
 
@@ -58,7 +51,7 @@ Returned data representing the state up until that point in time, rather than th
 |:------------|:--------------|
 | `200`       | Success       |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/transaction-with-transfers.mdx
+++ b/content/docs/stacks/api/accounts/transaction-with-transfers.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/{tx_id}/with_transfers`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/{tx_id}/with_transfers"}>
 
 **NOTE:** This endpoint has been <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> and may be removed in future versions of the API.
 
@@ -53,7 +46,7 @@ Transaction id
 | `200` | Success |
 | `404` | Not found |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/transactions-with-transfers.mdx
+++ b/content/docs/stacks/api/accounts/transactions-with-transfers.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/transactions_with_transfers`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/transactions_with_transfers"}>
 
 **NOTE:** This endpoint has been <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> and may be removed in future versions of the API.
 
@@ -88,7 +81,7 @@ Returned data representing the state up until that point in time, rather than th
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/accounts/transactions.mdx
+++ b/content/docs/stacks/api/accounts/transactions.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/address/{principal}/transactions`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/address/{principal}/transactions"}>
 
 **NOTE:** This endpoint has been <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> and may be removed in future versions of the API.
 
@@ -90,7 +83,7 @@ returned data representing the state up until that point in time, rather than th
 |:------------|:--------------|
 | `200`       | Success       |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/block-by-burn-block-hash.mdx
+++ b/content/docs/stacks/api/blocks/block-by-burn-block-hash.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/block/by_burn_block_hash/{burn_block_hash}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/block/by_burn_block_hash/{burn_block_hash}"}>
 
 **NOTE:** This endpoint is <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> in favor of [Get blocks by burn block](/stacks/api/blocks/get-blocks-by-burn-block).
 
@@ -36,7 +28,7 @@ Retrieves block details of a specific block for a given burnchain block hash
 | `200` | Block |
 | `404` | Cannot find block with given height |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/block-by-burn-block-height.mdx
+++ b/content/docs/stacks/api/blocks/block-by-burn-block-height.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/block/by_burn_block_height/{burn_block_height}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/block/by_burn_block_height/{burn_block_height}"}>
 
 **NOTE:** This endpoint is <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> in favor of [Get blocks by burn block](/stacks/api/blocks/get-blocks-by-burn-block).
 
@@ -36,7 +28,7 @@ Retrieves block details of a specific block for a given burn chain height
 | `200` | Block |
 | `404` | Cannot find block with given height |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/block-by-hash.mdx
+++ b/content/docs/stacks/api/blocks/block-by-hash.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/block/{hash}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/block/{hash}"}>
 
 **NOTE:** This endpoint is <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> in favor of [Get block](/stacks/api/blocks/get-block).
 
@@ -36,7 +28,7 @@ Retrieves block details of a specific block for a given chain height. You can us
 | `200` | Block |
 | `404` | Cannot find block with given ID |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/block-by-height.mdx
+++ b/content/docs/stacks/api/blocks/block-by-height.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/block/by_height/{height}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/block/by_height/{height}"}>
 
 **NOTE:** This endpoint is <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> in favor of [Get block](/stacks/api/blocks/get-block).
 
@@ -36,7 +28,7 @@ Retrieves block details of a specific block at a given block height
 | `200` | Block |
 | `404` | Cannot find block with given height |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/get-block.mdx
+++ b/content/docs/stacks/api/blocks/get-block.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/blocks/{height_or_hash}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/blocks/{height_or_hash}"}>
 
 Retrieves a single block
 
@@ -41,7 +33,7 @@ Filter by block height, hash, index block hash or the constant `latest` to filte
 | :----------- | :----------- |
 | `200` | Block |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/get-blocks-by-burn-block.mdx
+++ b/content/docs/stacks/api/blocks/get-blocks-by-burn-block.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/burn-blocks/{height_or_hash}/blocks`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/burn-blocks/{height_or_hash}/blocks"}>
 
 Retrieves a list of blocks confirmed by a specific burn block.
 
@@ -59,7 +51,7 @@ Index of first burn block to fetch
 | :----------- | :----------- |
 | `200` | List of blocks |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/get-blocks.mdx
+++ b/content/docs/stacks/api/blocks/get-blocks.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/blocks`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/blocks"}>
 
 Retrieves a list of recently mined blocks. If you need to actively monitor new blocks, we highly recommend using the [`@stacks/blockchain-api-client`](/stacks/api/client) library for real-time updates.
 
@@ -51,7 +43,7 @@ Index of first burn block to fetch
 | :----------- | :----------- |
 | `200` | List of blocks |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/blocks/recent-blocks.mdx
+++ b/content/docs/stacks/api/blocks/recent-blocks.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/block`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/block"}>
 
 **NOTE:** This endpoint is <span className="rounded-lg border px-1 py-0.5 text-xs font-medium border-orange-400/50 bg-orange-400/20 text-orange-600 dark:text-orange-400">deprecated</span> in favor of [Get blocks](/stacks/api/blocks/get-blocks).
 
@@ -55,7 +47,7 @@ Index of first block to fetch
 | :----------- | :----------- |
 | `200` | List of blocks |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/burn-blocks/get-burn-block.mdx
+++ b/content/docs/stacks/api/burn-blocks/get-burn-block.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/burn-blocks/{height_or_hash}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/burn-blocks/{height_or_hash}"}>
 
 Retrieves a single burn block.
 
@@ -41,7 +33,7 @@ Filter by burn block height, hash, or the constant `latest` to filter for the mo
 | :----------- | :----------- |
 | `200` | Burn block |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/burn-blocks/get-burn-blocks.mdx
+++ b/content/docs/stacks/api/burn-blocks/get-burn-blocks.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/burn-blocks`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/burn-blocks"}>
 
 Retrieves a list of recent burn blocks.
 
@@ -53,7 +45,7 @@ Index of first burn block to fetch
 | :----------- | :----------- |
 | `200` | List of burn blocks |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/faucets/btc.mdx
+++ b/content/docs/stacks/api/faucets/btc.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-yellow-400/50 bg-yellow-400/20 text-yellow-600 dark:text-yellow-400">
-    POST
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/faucets/btc`}</p>
-</h2>
+<APIInfo method={"POST"} route={"/extended/v1/faucets/btc"}>
 
 Add 1 BTC token to the specified testnet BTC address.
 
@@ -42,7 +35,7 @@ BTC testnet address
 | `403`       | BTC Faucet not fully configured  |
 | `500`       | Faucet call failed               |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/faucets/stx.mdx
+++ b/content/docs/stacks/api/faucets/stx.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-yellow-400/50 bg-yellow-400/20 text-yellow-600 dark:text-yellow-400">
-    POST
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/faucets/stx`}</p>
-</h2>
+<APIInfo method={"POST"} route={"/extended/v1/faucets/stx"}>
 
 Add 500 STX tokens to the specified testnet address. Testnet STX addresses begin with `ST`. If the `stacking`
 parameter is set to `true`, the faucet will add the required number of tokens for individual stacking to the
@@ -58,7 +51,7 @@ Request the amount of STX tokens needed for individual address stacking
 | `200`       | Success           |
 | `500`       | Faucet call failed|
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/fees/estimate.mdx
+++ b/content/docs/stacks/api/fees/estimate.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-yellow-400/50 bg-yellow-400/20 text-yellow-600 dark:text-yellow-400">
-    POST
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/fees/transaction`}</p>
-</h2>
+<APIInfo method={"POST"} route={"/v2/fees/transaction"}>
 
 Get an estimated fee for a supplied transaction.  This
 estimates the execution cost of the transaction, the current
@@ -92,8 +84,6 @@ this fee amount by:
 
 ### Request body (optional)
 
-
-
 <Property required={true} deprecated={false} name={"transaction_payload"} type={"string"}>
 
 
@@ -103,14 +93,13 @@ this fee amount by:
 <Property required={false} deprecated={false} name={"estimated_len"} type={"integer"}>
 
 
-
 </Property>
 
 | Status code | Description |
 | :--------- | :---------- |
 | `200` | Estimated fees for the transaction |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/fees/transfer-estimate.mdx
+++ b/content/docs/stacks/api/fees/transfer-estimate.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/fees/transfer`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v2/fees/transfer"}>
 
 Retrieves an estimated fee rate for STX transfer transactions. This a a fee rate / byte, and is returned as a JSON integer
 
@@ -33,7 +25,7 @@ Retrieves an estimated fee rate for STX transfer transactions. This a a fee rate
 | :--------- | :---------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/circulating-stx-supply-in-plain-text.mdx
+++ b/content/docs/stacks/api/info/circulating-stx-supply-in-plain-text.mdx
@@ -5,6 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
+import { APIInfo } from 'fumadocs-ui/components/api'
 import { Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
@@ -13,22 +14,15 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/stx_supply/circulating/plain`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/stx_supply/circulating/plain"}>
 
 Retrieves the STX tokens currently in circulation that have been unlocked as plain text.
 
 | Status code | Description |
 |:------------|:------------|
-| `200`       | success     |
+| `200`       | Success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/core-api.mdx
+++ b/content/docs/stacks/api/info/core-api.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,26 +13,15 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/info`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/info"}>
 
 Retrieves information about the Core API including the server version
-
-### Parameters
-
-No parameters.
 
 | Status code | Description |
 | :---------- | :---------- |
 | `200`       | Success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/legacy-total-and-unlocked-stx-supply.mdx
+++ b/content/docs/stacks/api/info/legacy-total-and-unlocked-stx-supply.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,19 +13,11 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/stx_supply/legacy_format`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/stx_supply/legacy_format"}>
 
 Retrieves total supply of STX tokens including those currently in circulation that have been unlocked.
 
 **Note:** this uses the estimated future total supply for the year 2050.
-
 
 ### Query parameters
 
@@ -41,7 +33,7 @@ Supply details are queried from a specified block height. If the block height is
 |:------------|:------------|
 | `200`       | Success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/network-block-time.mdx
+++ b/content/docs/stacks/api/info/network-block-time.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/info/network_block_times`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/info/network_block_times"}>
 
 Retrieves the target block times for mainnet and testnet. The block time is hardcoded and will change throughout the implementation phases of testnet.
 
@@ -32,7 +25,7 @@ No parameters.
 |:------------|:------------|
 | `200`       | Success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/network-given-block-time.mdx
+++ b/content/docs/stacks/api/info/network-given-block-time.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/info/network_block_time/{network}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/info/network_block_time/{network}"}>
 
 Retrieves the target block time for a given network. The network can be mainnet or testnet. The block time is hardcoded and will change throughout the implementation phases of testnet.
 
@@ -40,7 +33,7 @@ the target block time for a given network (testnet, mainnet).
 | ----------- | ----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/pox-details.mdx
+++ b/content/docs/stacks/api/info/pox-details.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/pox`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v2/pox"}>
 
 Retrieves Proof-of-Transfer (PoX) information. Can be used for Stacking.
 
@@ -28,7 +21,7 @@ Retrieves Proof-of-Transfer (PoX) information. Can be used for Stacking.
 |:------------|:--------------|
 | `200`       | Success       |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/status.mdx
+++ b/content/docs/stacks/api/info/status.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended"}>
 
 Retrieves the running status of the Stacks Blockchain API, including the server version and current chain tip information.
 
@@ -32,7 +25,7 @@ No parameters.
 |:------------|:------------|
 | `200`       | Success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/total-and-unlocked-stx-supply.mdx
+++ b/content/docs/stacks/api/info/total-and-unlocked-stx-supply.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/stx_supply`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/stx_supply"}>
 
 Retrieves the total and unlocked STX supply. More information on Stacking can be found [here](https://docs.stacks.co/understand-stacks/stacking).
 
@@ -40,7 +33,7 @@ Supply details are queried from a specified block height. If the block height is
 |:------------|:--------------|
 | `200`       | Success       |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/info/total-stx-supply-in-plain-text.mdx
+++ b/content/docs/stacks/api/info/total-stx-supply-in-plain-text.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/stx_supply/total/plain`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/stx_supply/total/plain"}>
 
 Retrieves the total supply for STX tokens as plain text.
 
@@ -30,7 +23,7 @@ Retrieves the total supply for STX tokens as plain text.
 |:------------|:------------|
 | `200`       | success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/mempool/transaction-fee-priorities.mdx
+++ b/content/docs/stacks/api/mempool/transaction-fee-priorities.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/mempool/fees`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/mempool/fees"}>
 
 Returns estimated fee priorities (in micro-STX) for all transactions that are currently in the mempool. Also returns priorities separated by transaction type.
 
@@ -33,7 +25,7 @@ Returns estimated fee priorities (in micro-STX) for all transactions that are cu
 | :----------- | :----------- |
 | `200` | Mempool fee priorities |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/historical-zonefile.mdx
+++ b/content/docs/stacks/api/names/historical-zonefile.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/names/{name}/zonefile/{zoneFileHash}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/names/{name}/zonefile/{zoneFileHash}"}>
 
 Retrieves the historical zonefile specified by the username and zone hash.
 
@@ -53,7 +45,7 @@ Zone file hash
 | `400` | Error |
 | `404` | Error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/name-details.mdx
+++ b/content/docs/stacks/api/names/name-details.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/names/{name}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/names/{name}"}>
 
 Retrieves details of a given name including the `address`, `status` and last transaction ID `last_txid`.
 
@@ -45,7 +37,7 @@ Fully-qualified name
 | `400` | Error |
 | `404` | Error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/name-price.mdx
+++ b/content/docs/stacks/api/names/name-price.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/prices/names/{name}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v2/prices/names/{name}"}>
 
 Retrieves the price of a name. The `amount` given will be in the smallest possible units of the currency.
 
@@ -43,7 +35,7 @@ The name to query price information for
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/name-subdomains.mdx
+++ b/content/docs/stacks/api/names/name-subdomains.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/names/{name}/subdomains`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/names/{name}/subdomains"}>
 
 Retrieves the list of subdomains for a specific name
 
@@ -43,7 +35,7 @@ Fully-qualified name
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/name-zonefile.mdx
+++ b/content/docs/stacks/api/names/name-zonefile.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/names/{name}/zonefile`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/names/{name}/zonefile"}>
 
 Retrieves a user’s raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files.
 
@@ -45,7 +37,7 @@ Fully-qualified name
 | `400` | Error |
 | `404` | Error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/names.mdx
+++ b/content/docs/stacks/api/names/names.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/names`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/names"}>
 
 Retrieves a list of all names known to the node.
 
@@ -44,7 +36,7 @@ Names are defaulted to page 1 with 100 results. You can query specific page resu
 | `200` | Success |
 | `400` | Error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/namespace-names.mdx
+++ b/content/docs/stacks/api/names/namespace-names.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/namespaces/{tld}/names`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/namespaces/{tld}/names"}>
 
 Retrieves a list of names within a given namespace.
 
@@ -55,7 +47,7 @@ Namespace values are defaulted to page 1 with 100 results. You can query specifi
 | `400` | Error |
 | `404` | Error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/namespace-price.mdx
+++ b/content/docs/stacks/api/names/namespace-price.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/prices/namespaces/{tld}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v2/prices/namespaces/{tld}"}>
 
 Retrieves the price of a namespace. The `amount` given will be in the smallest possible units of the currency.
 
@@ -43,7 +35,7 @@ The namespace to fetch price for
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/namespaces.mdx
+++ b/content/docs/stacks/api/names/namespaces.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,22 +17,15 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/namespaces`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/namespaces"}>
 
 Retrieves a list of all namespaces known to the node.
 
 | Status code | Description |
-| ----------- | ----------- |
+| :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/names/owned-by-address.mdx
+++ b/content/docs/stacks/api/names/owned-by-address.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v1/addresses/{blockchain}/{address}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v1/addresses/{blockchain}/{address}"}>
 
 Retrieves a list of names owned by the address provided.
 
@@ -52,7 +44,7 @@ The address to lookup
 | `200` | Success |
 | `404` | Error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/non-fungible-tokens/history.mdx
+++ b/content/docs/stacks/api/non-fungible-tokens/history.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/tokens/nft/history`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/tokens/nft/history"}>
 
 Retrieves all events relevant to a non-fungible token. This is useful when determining the ownership history of a particular asset.
 
@@ -89,7 +81,7 @@ Whether or not to include the complete transaction metadata instead of just `tx_
 | :----------- | :----------- |
 | `200` | Non-fungible token event history |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/non-fungible-tokens/holdings.mdx
+++ b/content/docs/stacks/api/non-fungible-tokens/holdings.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/tokens/nft/holdings`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/tokens/nft/holdings"}>
 
 Retrieves a list of non-fungible tokens owned by the given principal (STX address or smart contract ID).
 Results can be filtered by one or more asset identifiers and can include metadata about the transaction that made the principal own each token.
@@ -90,7 +82,7 @@ Whether or not to include the complete transaction metadata instead of just `tx_
 | :----------- | :----------- |
 | `200` | List of non-fungible token holdings |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/non-fungible-tokens/mints.mdx
+++ b/content/docs/stacks/api/non-fungible-tokens/mints.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/tokens/nft/mints`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/tokens/nft/mints"}>
 
 Retrieves all mint events for a non-fungible token asset class. This is useful to determine which NFTs of a particular collection have been claimed.
 
@@ -81,7 +73,7 @@ Whether or not to include the complete transaction metadata instead of just `tx_
 | :----------- | :----------- |
 | `200` | Non-Fungible Token mints |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/proof-of-transfer/cycle.mdx
+++ b/content/docs/stacks/api/proof-of-transfer/cycle.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/pox/cycles/{cycle_number}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/pox/cycles/{cycle_number}"}>
 
 Retrieves details for a PoX cycle.
 
@@ -43,7 +35,7 @@ PoX cycle number
 | :--------- | :---------- |
 | `200` | Details for cycle |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/proof-of-transfer/cycles.mdx
+++ b/content/docs/stacks/api/proof-of-transfer/cycles.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/pox/cycles`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/pox/cycles"}>
 
 Retrieves a list of PoX cycles.
 
@@ -53,7 +45,7 @@ index of first cycle to fetch
 | :--------- | :---------- |
 | `200` | List of cycles |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/proof-of-transfer/signer-in-cycle.mdx
+++ b/content/docs/stacks/api/proof-of-transfer/signer-in-cycle.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/pox/cycles/{cycle_number}/signers/{signer_key}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/pox/cycles/{cycle_number}/signers/{signer_key}"}>
 
 Retrieves details for a signer in a PoX cycle.
 
@@ -51,7 +43,7 @@ Signer key
 | :--------- | :---------- |
 | `200` | Details for PoX signer |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/proof-of-transfer/signers-in-cycle.mdx
+++ b/content/docs/stacks/api/proof-of-transfer/signers-in-cycle.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/pox/cycles/{cycle_number}/signers`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/pox/cycles/{cycle_number}/signers"}>
 
 Retrieves a list of signers in a PoX cycle.
 
@@ -43,7 +35,7 @@ PoX cycle number
 | :--------- | :---------- |
 | `200` | List of signers for cycle |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/proof-of-transfer/stackers-for-signer-in-cycle.mdx
+++ b/content/docs/stacks/api/proof-of-transfer/stackers-for-signer-in-cycle.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/pox/cycles/{cycle_number}/signers/{signer_key}/stackers`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/pox/cycles/{cycle_number}/signers/{signer_key}/stackers"}>
 
 Retrieves a list of stackers for a signer in a PoX cycle.
 
@@ -51,7 +43,7 @@ Signer key
 | :--------- | :---------- |
 | `200` | List of stackers |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/search/search-by-id.mdx
+++ b/content/docs/stacks/api/search/search-by-id.mdx
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/info`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/info"}>
 
 Search blocks, transactions, contracts, or accounts by hash/ID.
 
@@ -43,11 +36,11 @@ This includes the detailed data for purticular hash in the response
 </Property>
 
 | Status code | Description |
-| ----------- | ----------- |
+| :----------- | :----------- |
 | `200` | Success |
 | `404` | Not found |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/by-trait.mdx
+++ b/content/docs/stacks/api/smart-contracts/by-trait.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/contract/by_trait`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/contract/by_trait"}>
 
 Retrieves a list of contracts based on the following traits listed in JSON format -  functions, variables, maps, fungible tokens and non-fungible tokens.
 
@@ -53,7 +45,7 @@ Index of first contract event to fetch
 | :----------- | :----------- |
 | `200` | List of contracts implement given trait |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/events.mdx
+++ b/content/docs/stacks/api/smart-contracts/events.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/contract/{contract_id}/events`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/contract/{contract_id}/events"}>
 
 Retrieves a list of events that have been triggered by a given `contract_id`.
 
@@ -69,7 +61,7 @@ Include transaction data from unanchored (i.e. unconfirmed) microblocks
 | :----------- | :----------- |
 | `200` | List of events |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/info.mdx
+++ b/content/docs/stacks/api/smart-contracts/info.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/contract/{contract_id}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/contract/{contract_id}"}>
 
 Retrieves details of a contract with a given `contract_id`.
 
@@ -34,7 +26,7 @@ Retrieves details of a contract with a given `contract_id`.
 | `200` | Contract found |
 | `404` | Cannot find contract of given ID |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/interface.mdx
+++ b/content/docs/stacks/api/smart-contracts/interface.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/contracts/interface/{contract_address}/{contract_name}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v2/contracts/interface/{contract_address}/{contract_name}"}>
 
 Retrieves a contract interface with a given `contract_address` and `contract name`.
 
@@ -33,7 +25,7 @@ Retrieves a contract interface with a given `contract_address` and `contract nam
 | :----------- | :----------- |
 | `200` | Contract interface |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/map-entry.mdx
+++ b/content/docs/stacks/api/smart-contracts/map-entry.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,21 +17,13 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-yellow-400/50 bg-yellow-400/20 text-yellow-600 dark:text-yellow-400">
-    POST
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/map_entry/{contract_address}/{contract_name}/{map_name}`}</p>
-</h2>
+<APIInfo method={"POST"} route={"/v2/map_entry/{contract_address}/{contract_name}/{map_name}"}>
 
 Attempt to fetch data from a contract data map. The contract is identified with a Stacks address `contract_address` and contract name `contract_address` in the URL path. The map is identified with [Map Name].
 
 The key to look up in the map is supplied via the POST body. This should be supplied as the hex string serialization of the key (which should be a Clarity value). Note: this is a JSON string atom.
 
 In the response, `data` is the hex serialization of the map response. Note: map responses are Clarity option types. For non-existent values, this is a serialized none, and for all other responses, it is a serialized (some ...) object.
-
 
 ### Request body
 
@@ -88,7 +79,7 @@ The Stacks chain tip to query from
 | `200` | Success |
 | `400` | Failed loading data map |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/read-only.mdx
+++ b/content/docs/stacks/api/smart-contracts/read-only.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-yellow-400/50 bg-yellow-400/20 text-yellow-600 dark:text-yellow-400">
-    POST
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/contracts/call-read/{contract_address}/{contract_name}/{function_name}`}</p>
-</h2>
+<APIInfo method={"POST"} route={"/v2/contracts/call-read/{contract_address}/{contract_name}/{function_name}"}>
 
 Call a read-only public function on a given smart contract.
 
@@ -85,7 +77,7 @@ The Stacks chain tip to query from
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/source.mdx
+++ b/content/docs/stacks/api/smart-contracts/source.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/contracts/source/{contract_address}/{contract_name}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/v2/contracts/source/{contract_address}/{contract_name}"}>
 
 Retrieves the Clarity source code of a given contract, along with the block height it was published in and the MARF proof for the data.
 
@@ -33,7 +25,7 @@ Retrieves the Clarity source code of a given contract, along with the block heig
 | :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/smart-contracts/status.mdx
+++ b/content/docs/stacks/api/smart-contracts/status.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,17 +17,9 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v2/smart-contracts/status`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v2/smart-contracts/status"}>
 
 Retrieves the deployment status of multiple smart contracts.
-
 
 ### Query parameters
 
@@ -44,7 +35,7 @@ Contract IDs to fetch status for
 | :----------- | :----------- |
 | `200` | List of smart contract status |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/stacking-pool/members.mdx
+++ b/content/docs/stacks/api/stacking-pool/members.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -17,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/beta/stacking/{pool_principal}/delegations`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/beta/stacking/{pool_principal}/delegations"}>
 
 Retrieves the list of stacking pool members for a given delegator principal.
 
@@ -77,10 +70,10 @@ Number of items to skip
 </Property>
 
 | Status code | Description |
-| ----------- | ----------- |
+| :----------- | :----------- |
 | `200` | Success |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/stacking-rewards/recent-burnchain-reward-recipient.mdx
+++ b/content/docs/stacks/api/stacking-rewards/recent-burnchain-reward-recipient.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/burnchain/rewards/{address}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/burnchain/rewards/{address}"}>
 
 Retrieves a list of recent burnchain (e.g. Bitcoin) rewards for the given recipient with the associated amounts and block info.
 
@@ -59,7 +51,7 @@ Index of first rewards to fetch
 | :----------- | :----------- |
 | `200` | List of burnchain reward recipients and amounts |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/stacking-rewards/recent-burnchain-reward-recipients.mdx
+++ b/content/docs/stacks/api/stacking-rewards/recent-burnchain-reward-recipients.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/burnchain/rewards`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/burnchain/rewards"}>
 
 Retrieves a list of recent burnchain (e.g. Bitcoin) reward recipients with the associated amounts and block info.
 
@@ -53,7 +45,7 @@ Index of first rewards to fetch
 | :----------- | :----------- |
 | `200` | List of burnchain reward recipients and amounts |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/stacking-rewards/recent-reward-slot-holder-entries.mdx
+++ b/content/docs/stacks/api/stacking-rewards/recent-reward-slot-holder-entries.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/burnchain/reward_slot_holders/{address}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/burnchain/reward_slot_holders/{address}"}>
 
 Retrieves a list of the Bitcoin addresses that would validly receive Proof-of-Transfer commitments for a given reward slot holder recipient address.
 
@@ -59,7 +51,7 @@ Index of the first items to fetch
 | :----------- | :----------- |
 | `200` | List of burnchain reward recipients and amounts |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/stacking-rewards/recent-reward-slot-holders.mdx
+++ b/content/docs/stacks/api/stacking-rewards/recent-reward-slot-holders.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/burnchain/reward_slot_holders`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/burnchain/reward_slot_holders"}>
 
 Retrieves a list of the Bitcoin addresses that would validly receive Proof-of-Transfer commitments.
 
@@ -53,7 +45,7 @@ Index of the first items to fetch
 | :----------- | :----------- |
 | `200` | List of burnchain reward recipients and amounts |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/stacking-rewards/total-burnchain-rewards-for-recipient.mdx
+++ b/content/docs/stacks/api/stacking-rewards/total-burnchain-rewards-for-recipient.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/extended/v1/burnchain/rewards/{address}/total`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/extended/v1/burnchain/rewards/{address}/total"}>
 
 Retrieves the total burnchain (e.g. Bitcoin) rewards for a given recipient `address`.
 
@@ -43,7 +35,7 @@ Reward recipient address. Should either be in the native burnchain's format (e.g
 | :----------- | :----------- |
 | `200` | List of burnchain reward recipients and amounts |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/api/transactions/broadcast-transaction.mdx
+++ b/content/docs/stacks/api/transactions/broadcast-transaction.mdx
@@ -5,8 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { APIInfo } from "fumadocs-ui/components/api"
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from 'fumadocs-ui/components/api'
 import { Badge } from '@/components/ui/badge';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Tabs as UITabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,14 +17,7 @@ import { InlineCode } from '@/components/inline-code';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-yellow-400/50 bg-yellow-400/20 text-yellow-600 dark:text-yellow-400">
-    POST
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/v2/transactions`}</p>
-</h2>
+<APIInfo method={"POST"} route={"/v2/transactions"}>
 
 Broadcasts raw transactions on the network. You can use the [@stacks/transactions](/stacks/stacks.js/packages/transactions) project to generate a raw transaction payload.
 
@@ -42,7 +34,7 @@ Broadcasts raw transactions on the network. You can use the [@stacks/transaction
 | `200` | Transaction id of successful post of a raw tx to the node's mempool |
 | `400` | Rejections result in a 400 error |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/token-metadata-api/info/status.mdx
+++ b/content/docs/stacks/token-metadata-api/info/status.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/metadata/v1/`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/metadata/v1/"}>
 
 Retrieves information about the Token Metadata API, including the server version.
 
@@ -32,7 +25,7 @@ No parameters.
 | :---------- | :---------- |
 | `200`       | Success     |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/token-metadata-api/tokens/fungible-token-metadata.mdx
+++ b/content/docs/stacks/token-metadata-api/tokens/fungible-token-metadata.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/metadata/v1/ft/{principal}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/metadata/v1/ft/{principal}"}>
 
 Retrieves metadata for a SIP-010 fungible token.
 
@@ -45,12 +38,12 @@ Principal for the contract which owns the SIP-010 token
 </Property>
 
 | Status code | Description |
-| ----------- | ----------- |
+| :----------- | :----------- |
 | `200` | Default response |
 | `404` | Default response |
 | `422` | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/token-metadata-api/tokens/fungible-tokens.mdx
+++ b/content/docs/stacks/token-metadata-api/tokens/fungible-tokens.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/metadata/v1/ft`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/metadata/v1/ft"}>
 
 Retrieves a list of fungible tokens.
 
@@ -82,7 +75,7 @@ Results order
 | :---------- | :-------------- |
 | `200`       | Default response|
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/token-metadata-api/tokens/non-fungible-token-metadata.mdx
+++ b/content/docs/stacks/token-metadata-api/tokens/non-fungible-token-metadata.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/metadata/v1/nft/{principal}/{token_id}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/metadata/v1/nft/{principal}/{token_id}"}>
 
 Retrieves metadata for a SIP-009 non-fungible token.
 
@@ -53,12 +46,12 @@ Token ID to retrieve
 </Property>
 
 | Status code | Description |
-| ----------- | ----------- |
+| :----------- | :----------- |
 | `200` | Default response |
 | `404` | Default response |
 | `422` | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 

--- a/content/docs/stacks/token-metadata-api/tokens/semi-fungible-token-metadata.mdx
+++ b/content/docs/stacks/token-metadata-api/tokens/semi-fungible-token-metadata.mdx
@@ -5,7 +5,7 @@ toc: false
 ---
 
 import { Root, API, APIExample } from '@/components/layout';
-import { Property } from 'fumadocs-ui/components/api'
+import { APIInfo, Property } from "fumadocs-ui/components/api"
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
@@ -13,14 +13,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <API>
 
-<div className='flex-1'>
-
-<h2 className="not-prose mb-2 inline-flex items-center gap-3 font-mono">
-  <div className="rounded-lg border px-1 py-0.5 text-xs font-medium border-green-400/50 bg-green-400/20 text-green-600 dark:text-green-400">
-    GET
-  </div>
-  <p className="text-xs break-words overflow-hidden w-[95%]">{`/metadata/v1/sft/{principal}/{token_id}`}</p>
-</h2>
+<APIInfo method={"GET"} route={"/metadata/v1/sft/{principal}/{token_id}"}>
 
 Retrieves metadata for a SIP-013 semi-fungible token.
 
@@ -53,12 +46,12 @@ Token ID to retrieve
 </Property>
 
 | Status code | Description |
-| ----------- | ----------- |
+| :----------- | :----------- |
 | `200` | Default response |
 | `404` | Default response |
 | `422` | Default response |
 
-</div>
+</APIInfo>
 
 <APIExample>
 


### PR DESCRIPTION
## What does this PR do?

Refactor to use the `APIInfo` component from `fumadocs-ui` for a more standardized approach when generating openapi specs