### PR TITLE
Add Security Headers to Improve Site Protection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,16 @@
 {
   "cleanUrls": true,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/",


### PR DESCRIPTION
## What does this PR do?

This PR introduces the `Cross-Origin-Opener-Policy: same-origin` header across all responses from our docs site. This header is crucial for preventing cross-origin information leakage and potential security threats.

- Updated the `vercel.json` configuration to include a new headers section.
- Added the `Cross-Origin-Opener-Policy` with a value of `same-origin` to apply to all paths (/(.*)).
