### PR TITLE
update rate limit to reflect the change back to 100RPM

### DIFF
--- a/content/docs/stacks/api/usage.mdx
+++ b/content/docs/stacks/api/usage.mdx
@@ -46,7 +46,7 @@ The Stacks API uses standard HTTP response codes to indicate the success or fail
 
 | API key | Rate limit                        |
 |:--------|:----------------------------------|
-| No      | 50 requests per minute (RPM) per client IP, for unauthenticated traffic |
+| No      | 100 requests per minute (RPM) per client IP, for unauthenticated traffic |
 | Yes     | 500 requests per minute (RPM) regardless of origin IP, with an authenticated API key |
 
 <Callout title="Rate limits" type="info">

--- a/snippets/rate-limiting.mdx
+++ b/snippets/rate-limiting.mdx
@@ -4,7 +4,7 @@ The following rate-limits (in requests per minute, or RPM) are applicable for al
 
 | API key | Rate Limit                        |
 |:--------|:----------------------------------|
-| No      | 50 requests per minute (RPM) per client IP, for unauthenticated traffic |
+| No      | 100 requests per minute (RPM) per client IP, for unauthenticated traffic |
 | Yes     | 500 requests per minute (RPM), regardless of origin IP, with an authenticated API key |
 
 These rate-limits apply to the entirety of API traffic, regardless of whether it's from one or all of these APIs:


### PR DESCRIPTION
## What does this PR do?

The rate limit for API requests has moved from 50-100. This PR updates all references to reflect that change.