### PR TITLE
feat: update nakamoto docs for clarinet

### DIFF
--- a/content/docs/stacks/nakamoto/guides/clarinet.mdx
+++ b/content/docs/stacks/nakamoto/guides/clarinet.mdx
@@ -3,45 +3,48 @@ title: Updates for Clarinet
 description: Discover Clarinet upgrades related to the Nakamoto release.
 ---
 
-## Launch devnet in Nakamoto mode
+## Setting up a project for Nakamoto
 
-As of [Clarinet 2.4.0](https://github.com/hirosystems/clarinet/releases/tag/v2.4.0), devnet can run the blockchain in Nakamoto mode.
+As of [Clarinet 2.8.0](https://github.com/hirosystems/clarinet/releases/tag/v2.8.0), devnet can run
+the blockchain in Nakamoto mode and support Clarity 3 contracts.
 
-Once your devnet reaches the right block height, it will deploy the `pox-4.clar` contract and run in
-Epoch 2.5.
-From there, Clarinet will send `stack-stx` and `stack-extend` requests to the new PoX contract.
-In Nakamoto mode, devnet has 2 signers. Eventually, you can observe the
-`vote-for-aggregate-public-key` transactions that they send.
+Once the devnet reaches the right block height, (Bitcoin block #108 by default), it will deploy the
+`pox-4.clar` contract and run in Epoch 2.5. From there, Clarinet will send `stack-stx` and
+`stack-extend` requests to the new PoX contract. In Nakamoto mode, devnet has 2 signers. Eventually,
+you can observe the `vote-for-aggregate-public-key` transactions that they send.
 
-Do not expect to reach Epoch 3.0 with Clarinet 2.4.0. This release is focusing on Epoch 2.5.
-Epoch 3.0, with fast blocks and others improvements, will come in a future release.
-
-### Setting up a project for Nakamoto
-
-Using one of your Clarinet projects, or a new one (with `clarinet new nakamoto-project`), update the
-`settings/Devnet.toml`.
-
-Under the `[devnet]` section when `use_nakamoto = true` is set, the `pox-4.clar` contract should be
-deployed around the **Bitcoin block 108**.
+By default, the Devnet will not get to Epoch 3.0 ("Nakamoto activation" with fast blocks). For that, the `epoch_3_0` height as to be set manually in the `Devnet.toml` file. Using one of your Clarinet projects, or a new one (with `$ clarinet new nakademo`), update the
+`settings/Devnet.toml` with the following settings:
 
 ```toml
 [devnet]
-use_nakamoto = true
+epoch_3_0 = 144
+
+stacks_node_image_url = "quay.io/hirosystems/stacks-node:devnet-3.0"
+stacks_signer_image_url = "quay.io/hirosystems/stacks-signer:devnet-3.0"
+```
+
+Set a contract to be deployed in epoch 3.0 with Clarity 3. You can create a new one with `$ clarinet contract new nakademo`). It needs to be manually update in the project manifest (Clarinet.toml)
+
+```toml
+[contracts.nakademo]
+path = 'contracts/nakademo.clar'
+clarity_version = 3
+epoch = 3.0
 ```
 
 Start devnet with `clarinet devnet start`.
 
-## Deploy contracts on the Nakamoto Testnet
+## Deploy contracts on the Nakamoto Testnets
 
-A Nakamoto testnet is available and running in Epoch 2.5. Clarinet can be used to deploy contracts
-on testnet.
+A Nakamoto testnet is available and running in Epoch 3.0. Clarinet can be used to deploy Clarity 3 contracts on this tesnet.
 
 In a Clarinet project, the `settings/Testnet.toml` file can be updated like so:
 
 ```toml
 [network]
 name = "testnet"
-stacks_node_rpc_address = "https://api.testnet.hiro.so"
+stacks_node_rpc_address = "https://api.nakamoto-1.hiro.so"
 deployment_fee_rate = 10
 
 [accounts.deployer]


### PR DESCRIPTION
## Description

Update the Clarinet upgrades for nakamoto page to reflect the new epoch 3.0 and clarity 3 changes available in Clarinet 2.8.0.

Allowing developer to use Clarity 3 and experience fast blocks locally

