### PR TITLE
Update bitcoin-node.mdx

### DIFF
--- a/content/docs/stacks/platform-api/devnet/bitcoin-node.mdx
+++ b/content/docs/stacks/platform-api/devnet/bitcoin-node.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bitcoin Node
+title: Bitcoin node
 description: Proxy for the Bitcoin node on a development network (devnet).
 toc: false
 ---
@@ -26,13 +26,13 @@ import {
 
 <APIInfo method={"GET"} route={"/v1/ext/{apiKey}/bitcoin-node/{*}"}>
 
-## Bitcoin Node
+## Bitcoin node
 
 This endpoint is designed to proxy requests to the Bitcoin node on a development network (devnet).
 
 It is accessible only with an API key and supports various HTTP methods (GET, POST, PUT, DELETE, PATCH, OPTIONS).
 
-### Path Parameters
+### Path parameters
 
 <Property name={"apiKey"} type={"string"} required={true} deprecated={false}>
 
@@ -128,7 +128,7 @@ This endpoint is designed to proxy requests to the Bitcoin node on a development
 
 It is accessible only with an API key and supports various HTTP methods (GET, POST, PUT, DELETE, PATCH, OPTIONS).
 
-### Path Parameters
+### Path parameters
 
 <Property name={"apiKey"} type={"string"} required={true} deprecated={false}>
 


### PR DESCRIPTION
tweaked grammar on the Bitcoin node page

Question for @ryanwaits - the `get` and `post` section have identical copy. That feels like copy/pasta and the `post` section should have different language than "This endpoint is designed to proxy requests to the Bitcoin node on a development network (devnet)." but I defer to you there.