### PR TITLE
fix: truncated endpoints

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -306,16 +306,37 @@ div.prose-no-margin .sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.roun
   top: 4.5rem;
 }
 
-/* For long endpoint names this will truncate the ending and add an ellipsis */
-div.prose-no-margin .sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.rounded-lg.border.bg-card.p-3.md\:top-10 span:nth-child(n+12) {
-  display: none;
+/* START Wrap longer endpoionts */
+
+/* Target the sticky outer div */
+.sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.rounded-lg.border.bg-card.p-3.md\:top-10 {
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 2.5rem;
 }
 
-/* And add an ellipsis */
-div.prose-no-margin .sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.rounded-lg.border.bg-card.p-3.md\:top-10 span:nth-child(11)::after {
-  content: '...';
-  display: inline;
+/* Style for the POST span */
+.sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.rounded-lg.border.bg-card.p-3.md\:top-10 > span:first-child {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
 }
+
+/* Style for the button */
+.sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.rounded-lg.border.bg-card.p-3.md\:top-10 > button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+}
+
+/* Target the inner div containing the endpoint spans */
+.sticky.top-24.z-\[2\].flex.flex-row.items-center.gap-2.rounded-lg.border.bg-card.p-3.md\:top-10 > div {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+/* END Wrap longer endpoionts */
 
 div.prose div.footer.not-prose {
   background: hsl(var(--accent));


### PR DESCRIPTION
## What does this PR do?

Addresses the issue with longer endpoints truncating in API Reference pages.

Issue: https://github.com/hirosystems/docs/issues/742

<img width="736" alt="Screenshot 2024-08-21 at 10 16 26 AM" src="https://github.com/user-attachments/assets/88c89990-6d75-4a67-97ff-451475fee2ba">
