### PR TITLE
Update no-loss-lottery.mdx

### DIFF
--- a/content/docs/guides/no-loss-lottery.mdx
+++ b/content/docs/guides/no-loss-lottery.mdx
@@ -201,7 +201,7 @@ To bootstrap the CityCoins contracts, follow these steps:
 
 <Cards>
   <Card
-    href="/stacks/clarinet/guides/create-a-project"
+    href="/stacks/clarinet/guides/create-a-new-project"
     title="Create a new project"
     description="Learn how to create a new Clarinet project."
   />


### PR DESCRIPTION
There was a broken link to a Clarinet guide in the card at the bottom of this guide. This PR fixes that issue.
