### PR TITLE
Update deploy-project.mdx

### DIFF
--- a/content/docs/stacks/platform/guides/deploy-project.mdx
+++ b/content/docs/stacks/platform/guides/deploy-project.mdx
@@ -41,4 +41,4 @@ At any time, you can monitor your contract in the [Stacks Explorer](https://expl
 2. This button will open the Explorer to a page showing the contract you just deployed. From this page, you can see relevant information about your contract and the contract details.
 ![Explorer](../images/deploy-project/contract-on-explorer.png)
 
-If you find issues with your deployment process, you can refer to the [FAQ section](/stacks/platform/faqs) or file an issue [here](https://hiro-pbc.canny.io/hiro-platform).
+If you find issues with your deployment process, you can reach out to us on the [#hiro-platform channel](https://stacks.chat) on Discord under the Hiro Developer Tools section or file an issue [here](https://hiro-pbc.canny.io/hiro-platform).


### PR DESCRIPTION
This guide had a link to a Platform FAQs page at the bottom as a CTA, which had a 404 error. This removes that link and replaces it with a callout to reach out to us on Discord.