### PR TITLE
Update txs.mdx

### DIFF
--- a/content/docs/stacks/api/txs.mdx
+++ b/content/docs/stacks/api/txs.mdx
@@ -509,7 +509,7 @@ Sample response:
 
 #### Get mempool transactions
 
-Mempool (registered, but not processed) transactions can be obtained using the [`GET /extended/v1/tx/mempool`](stacks/api/transactions/mempool-transactions) endpoint:
+Mempool (registered, but not processed) transactions can be obtained using the [`GET /extended/v1/tx/mempool`](/stacks/api/transactions/mempool-transactions) endpoint:
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`
@@ -557,7 +557,7 @@ curl 'https://api.testnet.hiro.so/extended/v1/tx/?type=contract_call'
 
 #### Get transaction by ID
 
-A specific transaction can be obtained using the [`GET /extended/v1/tx/<tx_id>`](stacks/api/transactions/get-transaction) endpoint:
+A specific transaction can be obtained using the [`GET /extended/v1/tx/<tx_id>`](/stacks/api/transactions/get-transaction) endpoint:
 
 ```bash
 # for mainnet, replace `testnet` with `mainnet`


### PR DESCRIPTION
This page had two broken urls where `/stacks/api/` was repeated twice in the url structure. I think my fix fixes this, but this warrants testing to be sure.