### PR TITLE
api updates

### DIFF
--- a/content/docs/stacks/api/index.mdx
+++ b/content/docs/stacks/api/index.mdx
@@ -10,6 +10,10 @@ The Stacks Blockchain API expands the intentionally minimal RPC endpoints availa
 
 ## Popular endpoints
 
+<Callout title="RPC endpoints" type="info">
+For access to the RPC endpoints, use the `/v2` endpoint that forwards requests to the Stacks API node. For more information, see the [Stacks Node RPC API endpoints](https://docs.stacks.co/reference/api#stacks-node-rpc-api-endpoints) documentation.
+</Callout>
+
 <Cards>
   <SecondaryCard
     href="/stacks/api/transactions/recent-transactions"

--- a/content/docs/stacks/api/index.mdx
+++ b/content/docs/stacks/api/index.mdx
@@ -11,7 +11,7 @@ The Stacks Blockchain API expands the intentionally minimal RPC endpoints availa
 ## Popular endpoints
 
 <Callout title="RPC endpoints" type="info">
-For access to the RPC endpoints, use the `/v2` endpoint that forwards requests to the Stacks API node. For more information, see the [Stacks Node RPC API endpoints](https://docs.stacks.co/reference/api#stacks-node-rpc-api-endpoints) documentation.
+Use our `/v2` route to access the Stacks API node endpoints. For more information, see the [Stacks Node RPC API](https://docs.stacks.co/reference/api#stacks-node-rpc-api-endpoints) documentation.
 </Callout>
 
 <Cards>

--- a/content/docs/stacks/api/info/core-api.mdx
+++ b/content/docs/stacks/api/info/core-api.mdx
@@ -76,19 +76,19 @@ GET request that core node information
 
 ```json
 {
-  "peer_version": 0,
+  "peer_version": 402653194,
   "pox_consensus": "string",
-  "burn_block_height": 0,
+  "burn_block_height": 863576,
   "stable_pox_consensus": "string",
-  "stable_burn_block_height": 0,
+  "stable_burn_block_height": 863569,
   "server_version": "string",
-  "network_id": 0,
-  "parent_network_id": 0,
-  "stacks_tip_height": 0,
+  "network_id": 1,
+  "parent_network_id": 3652501241,
+  "stacks_tip_height": 167976,
   "stacks_tip": "string",
   "stacks_tip_consensus_hash": "string",
-  "unanchored_tip": "string",
-  "exit_at_block_height": 0
+  "unanchored_tip": null,
+  "exit_at_block_height": null
 }
 ```
 

--- a/content/docs/stacks/api/info/total-and-unlocked-stx-supply.mdx
+++ b/content/docs/stacks/api/info/total-and-unlocked-stx-supply.mdx
@@ -40,19 +40,11 @@ Supply details are queried from specified block height. If the block height is n
 
 </Property>
 
-<Property name={"unanchored"} type={"boolean"} required={false} deprecated={false}>
-
-Include data from unanchored (i.e. unconfirmed) microblocks
-
-<span>Default: `false`</span>
-
-</Property>
-
 | Status code | Description |
 | :----------- | :----------- |
 | `200` | GET request that returns total and unlocked STX supply |
 
-<APIPlayground authorization={undefined} method={"GET"} route={"/extended/v1/stx_supply/"} path={[]} query={[{"name":"height","type":"number","defaultValue":"","isRequired":false,"description":"Block height"},{"name":"unanchored","type":"boolean","defaultValue":"","isRequired":false}]} header={[]} body={undefined} schemas={{}}>
+<APIPlayground authorization={undefined} method={"GET"} route={"/extended/v1/stx_supply/"} path={[]} query={[{"name":"height","type":"number","defaultValue":"","isRequired":false,"description":"Block height"}]} header={[]} body={undefined} schemas={{}}>
 
 </APIPlayground>
 
@@ -65,7 +57,7 @@ Include data from unanchored (i.e. unconfirmed) microblocks
 <Request value={"cURL"}>
 
 ```bash
-curl -X GET "https://api.hiro.so/extended/v1/stx_supply/?height=0&unanchored=false"
+curl -X GET "https://api.hiro.so/extended/v1/stx_supply"
 ```
 
 </Request>
@@ -73,7 +65,7 @@ curl -X GET "https://api.hiro.so/extended/v1/stx_supply/?height=0&unanchored=fal
 <Request value={"JavaScript"}>
 
 ```js
-fetch("https://api.hiro.so/extended/v1/stx_supply/?height=0&unanchored=false", {
+fetch("https://api.hiro.so/extended/v1/stx_supply", {
   method: "GET"
 });
 ```

--- a/content/docs/stacks/api/info/total-and-unlocked-stx-supply.mdx
+++ b/content/docs/stacks/api/info/total-and-unlocked-stx-supply.mdx
@@ -28,27 +28,31 @@ import {
 
 ## Get total and unlocked STX supply
 
-Retrieves the total and unlocked STX supply. More information on Stacking can be found [here] (https://docs.stacks.co/understand-stacks/stacking).
-
-<Callout>
-This uses the estimated future total supply for the year 2050.
-</Callout>
+Retrieves the total and unlocked STX supply.
 
 ### Query Parameters
 
-<Property name={"height"} type={"number"} required={false} deprecated={false}>
+<Property name={"height"} type={"Block height"} required={false} deprecated={false}>
 
 Supply details are queried from specified block height. If the block height is not specified, the latest block height is taken as default value. Note that the `block height` is referred to the stacks blockchain.
 
-<span>Example: `200`</span>
+<span>Minimum: `0`</span>
+
+</Property>
+
+<Property name={"unanchored"} type={"boolean"} required={false} deprecated={false}>
+
+Include data from unanchored (i.e. unconfirmed) microblocks
+
+<span>Default: `false`</span>
 
 </Property>
 
 | Status code | Description |
-| :------ | :------ |
-| `200` | Success |
+| :----------- | :----------- |
+| `200` | GET request that returns total and unlocked STX supply |
 
-<APIPlayground authorization={undefined} method={"GET"} route={"/extended/v1/stx_supply"} path={[]} query={[{"name":"height","type":"number","defaultValue":200,"isRequired":false}]} header={[]} body={undefined} schemas={{}}>
+<APIPlayground authorization={undefined} method={"GET"} route={"/extended/v1/stx_supply/"} path={[]} query={[{"name":"height","type":"number","defaultValue":"","isRequired":false,"description":"Block height"},{"name":"unanchored","type":"boolean","defaultValue":"","isRequired":false}]} header={[]} body={undefined} schemas={{}}>
 
 </APIPlayground>
 
@@ -61,7 +65,7 @@ Supply details are queried from specified block height. If the block height is n
 <Request value={"cURL"}>
 
 ```bash
-curl -X GET "https://api.hiro.so/extended/v1/stx_supply?height=200"
+curl -X GET "https://api.hiro.so/extended/v1/stx_supply/?height=0&unanchored=false"
 ```
 
 </Request>
@@ -69,7 +73,7 @@ curl -X GET "https://api.hiro.so/extended/v1/stx_supply?height=200"
 <Request value={"JavaScript"}>
 
 ```js
-fetch("https://api.hiro.so/extended/v1/stx_supply?height=200", {
+fetch("https://api.hiro.so/extended/v1/stx_supply/?height=0&unanchored=false", {
   method: "GET"
 });
 ```
@@ -92,6 +96,7 @@ GET request that returns network target block times
 {
   "unlocked_percent": "string",
   "total_stx": "string",
+  "total_stx_year_2050": "string",
   "unlocked_stx": "string",
   "block_height": 0
 }
@@ -111,9 +116,13 @@ export interface GetStxSupplyResponse {
    */
   unlocked_percent: string;
   /**
-   * String quoted decimal number of the total possible number of STX
+   * String quoted decimal number of the total circulating number of STX (at the input block height if provided, otherwise the current block height)
    */
   total_stx: string;
+  /**
+   * String quoted decimal number of total circulating STX supply in year 2050. STX supply grows approx 0.3% annually thereafter in perpetuity.
+   */
+  total_stx_year_2050: string;
   /**
    * String quoted decimal number of the STX that have been mined or unlocked
    */

--- a/content/docs/stacks/api/smart-contracts/interface.mdx
+++ b/content/docs/stacks/api/smart-contracts/interface.mdx
@@ -90,7 +90,9 @@ GET request to get contract interface
   ],
   "non_fungible_tokens": [
     {}
-  ]
+  ],
+  "epoch": "string",
+  "clarity_version": "string"
 }
 ```
 

--- a/content/docs/stacks/api/stacking-pool/members.mdx
+++ b/content/docs/stacks/api/stacking-pool/members.mdx
@@ -24,7 +24,7 @@ import {
 
 <API>
 
-<APIInfo method={"GET"} route={"/extended/v1/pox3/{pool_principal}/delegations"}>
+<APIInfo method={"GET"} route={"/extended/v1/pox4/{pool_principal}/delegations"}>
 
 ## Stacking pool members
 
@@ -80,7 +80,7 @@ number of items to skip
 | :------ | :------ |
 | `200` | Success |
 
-<APIPlayground authorization={undefined} method={"GET"} route={"/extended/v1/pox3/{pool_principal}/delegations"} path={[{"name":"pool_principal","type":"string","defaultValue":"SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP","isRequired":true}]} query={[{"name":"after_block","type":"number","defaultValue":"","isRequired":false},{"name":"unanchored","type":"boolean","defaultValue":false,"isRequired":false},{"name":"limit","type":"number","defaultValue":3,"isRequired":false},{"name":"offset","type":"number","defaultValue":0,"isRequired":false}]} header={[]} body={undefined} schemas={{}}>
+<APIPlayground authorization={undefined} method={"GET"} route={"/extended/v1/pox4/{pool_principal}/delegations"} path={[{"name":"pool_principal","type":"string","defaultValue":"SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP","isRequired":true}]} query={[{"name":"after_block","type":"number","defaultValue":"","isRequired":false},{"name":"unanchored","type":"boolean","defaultValue":false,"isRequired":false},{"name":"limit","type":"number","defaultValue":3,"isRequired":false},{"name":"offset","type":"number","defaultValue":0,"isRequired":false}]} header={[]} body={undefined} schemas={{}}>
 
 </APIPlayground>
 
@@ -93,7 +93,7 @@ number of items to skip
 <Request value={"cURL"}>
 
 ```bash
-curl -X GET "https://api.hiro.so/extended/v1/pox3/SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP/delegations?unanchored=false&limit=5"
+curl -X GET "https://api.hiro.so/extended/v1/pox4/SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP/delegations?unanchored=false&limit=5"
 ```
 
 </Request>
@@ -101,7 +101,7 @@ curl -X GET "https://api.hiro.so/extended/v1/pox3/SP21YTSM60CAY6D011EZVEVNKXVW8F
 <Request value={"JavaScript"}>
 
 ```js
-fetch("https://api.hiro.so/extended/v1/pox3/SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP/delegations?after_block=0&unanchored=true&limit=100&offset=300", {
+fetch("https://api.hiro.so/extended/v1/pox4/SP21YTSM60CAY6D011EZVEVNKXVW8FVZE198XEFFP/delegations?after_block=0&unanchored=true&limit=100&offset=300", {
   method: "GET"
 });
 ```

--- a/content/docs/stacks/api/transactions/get-transaction.mdx
+++ b/content/docs/stacks/api/transactions/get-transaction.mdx
@@ -60,7 +60,7 @@ Transaction ID
 <Request value={"cURL"}>
 
 ```bash
-curl -X GET "https://api.hiro.so/extended/v1/tx/%7Btx_id%7D"
+curl -X GET "https://api.hiro.so/extended/v1/tx/{tx_id}"
 ```
 
 </Request>
@@ -68,7 +68,7 @@ curl -X GET "https://api.hiro.so/extended/v1/tx/%7Btx_id%7D"
 <Request value={"JavaScript"}>
 
 ```js
-fetch("https://api.hiro.so/extended/v1/tx/%7Btx_id%7D", {
+fetch("https://api.hiro.so/extended/v1/tx/{tx_id}", {
   method: "GET"
 });
 ```
@@ -81,7 +81,7 @@ fetch("https://api.hiro.so/extended/v1/tx/%7Btx_id%7D", {
 
 <Response value={"200"}>
 
-Describes all transaction types on Stacks 2.0 blockchain
+Fetches transaction details for a given transaction ID
 
 <ResponseTypes>
 

--- a/content/docs/stacks/api/usage.mdx
+++ b/content/docs/stacks/api/usage.mdx
@@ -16,7 +16,7 @@ https://api.mainnet.hiro.so
 To make a request to the Stacks API, you can paste the `curl` command below in your terminal.
 
 ```bash title="Terminal"
-curl -L 'https://api.hiro.so/v2/info' \
+curl -L 'https://api.hiro.so/extended' \
 -H 'Accept: application/json'
 ```
 
@@ -25,7 +25,7 @@ curl -L 'https://api.hiro.so/v2/info' \
 If you are using an `api-key`, you will need to replace `$HIRO_API_KEY` with your secret API key.
 
 ```bash title="Terminal"
-curl -L 'https://api.hiro.so/v2/info' \
+curl -L 'https://api.hiro.so/extended' \
 -H 'Accept: application/json' \
 -H 'X-API-Key: $HIRO_API_KEY' # [!code highlight]
 ```


### PR DESCRIPTION
## What does this PR do?

Updates several outdated examples and information in API References

- [x] Ref: https://github.com/hirosystems/docs/issues/778 Update references from `pox3` to `pox4`
- [x] Ref: https://github.com/hirosystems/docs/issues/753 Update copy and responses for `total_unlocked_stx_supply`
- [x] Ref: https://github.com/hirosystems/docs/issues/752 update `v2` endpoints
- [x] fix curl command example in api reference docs for v1/tx/:tx_id
- [x] Ref: https://github.com/hirosystems/docs/issues/780 updates to handling rpc endpoints