### PR TITLE
Update sync-a-bitcoin-node.mdx

### DIFF
--- a/content/docs/guides/sync-a-bitcoin-node.mdx
+++ b/content/docs/guides/sync-a-bitcoin-node.mdx
@@ -140,7 +140,7 @@ To start your node back up, all you need to do is refer to the previous steps fr
 
 <Cards>
   <Card
-    href="/stacks/chainhooks/guides/run-chainhook-as-a-service"
+    href="/stacks/chainhook/guides/chainhook-as-a-service"
     title="Run Chainhook as a service"
     description="Learn how to use Chainhook to build your own custom API."
   />


### PR DESCRIPTION
This PR fixes a broken link to the run chainhook as a service guide in the card at the bottom