### PR TITLE
Update sync-a-stacks-node.mdx

### DIFF
--- a/content/docs/guides/sync-a-stacks-node.mdx
+++ b/content/docs/guides/sync-a-stacks-node.mdx
@@ -56,7 +56,7 @@ For networks other than `mocknet`, downloading the initial headers can take seve
 
 <Cards>
   <Card
-    href="/stacks/chainhooks/guides/run-chainhook-as-a-service"
+    href="/stacks/chainhook/guides/chainhook-as-a-service"
     title="Run Chainhook as a service"
     description="Learn how to use Chainhook to build your own custom API."
   />


### PR DESCRIPTION
This PR fixes a broken link to the Chainhook card at the bottom of this page.
