### PR TITLE
Update ordhook-as-a-service.mdx

### DIFF
--- a/content/docs/bitcoin/ordinals/ordhook/guides/ordhook-as-a-service.mdx
+++ b/content/docs/bitcoin/ordinals/ordhook/guides/ordhook-as-a-service.mdx
@@ -115,7 +115,7 @@ A comprehensive OpenAPI specification explaining how to interact with this HTTP 
 
 <Cards>
   <Card
-    href="/ordinals/ordhook/guides/stream-ordinals-activity"
+    href="/bitcoin/ordinals/ordhook/guides/stream-ordinals-activity"
     title="Stream Ordinals Activity"
     description="Learn how to stream Ordinals activity to a server."
   />


### PR DESCRIPTION
Fixes a broken link in the card at the bottom
