### PR TITLE
Update quickstart.mdx

### DIFF
--- a/content/docs/stacks/clarinet/quickstart.mdx
+++ b/content/docs/stacks/clarinet/quickstart.mdx
@@ -10,7 +10,7 @@ import { SmallCard } from '@/components/card';
 
 In this quickstart guide, you will write a simple counter contract with Clarity. Throughout this tutorial, you'll learn how to generate a new project, create a smart contract, and validate your smart contract code using the Clarinet CLI.
 
-Check out the [create a new project](/stacks/clarinet/guides/create-a-new-project) and [validate a contract](/stacks/clarinet/guides/deploy-a-contract) guides for a deeper look.
+Check out the [create a new project](/stacks/clarinet/guides/create-a-new-project) and [validate a contract](/stacks/clarinet/guides/validate-a-contract) guides for a deeper look.
 
 ---
 
@@ -147,7 +147,7 @@ Check out the [create a new project](/stacks/clarinet/guides/create-a-new-projec
     description="Learn how to set up and run a local development network for your project."
   />
   <Card
-    href="/stacks/clarinet/guides/testing-with-clarinet-sdk"
+    href="/stacks/clarinet-js-sdk/quickstart"
     title="Testing with the Clarinet JS SDK"
     description="Learn how to test your smart contracts using the Clarinet JS SDK."
   />


### PR DESCRIPTION
Fixes a 404 link for the Clarinet SDK card at the bottom of the page.

This also swaps out a link for the validate a project guide, which previously incorrectly pointed to the deployment guide
