### PR TITLE
Update deployment-plans.mdx

### DIFF
--- a/content/docs/stacks/platform/guides/deployment-plans.mdx
+++ b/content/docs/stacks/platform/guides/deployment-plans.mdx
@@ -50,7 +50,7 @@ It's possible that the transaction may fail in the deployment process for a numb
 
 ## Deploy individual contract
 
-If you want to deploy an individual contract (and not the entire project), you can click the three dots next to the contract name in your project list and click "Deploy to testnet" or "Deploy to mainnet." You will then be prompted to confirm if you want to deploy outside of your deployment plan or use a deployment plan. If you choose to deploy using a deployment plan, follow the steps described above in this article's [deploy](#deploy) section.
+If you want to deploy an individual contract (and not the entire project), you can click the three dots next to the contract name in your project list and click "Deploy to testnet" or "Deploy to mainnet." You will then be prompted to confirm if you want to deploy outside of your deployment plan or use a deployment plan. If you choose to deploy using a deployment plan, follow the steps described above in this article's [deploy](#deploy-your-project) section.
 
 ![Confirmation to deploy outside of deployment plan](../images/deployment-plans/deploy-outside-of-deployment-plan.png)
 
@@ -81,6 +81,6 @@ Select the "Remove" button to remove the generated deployment plan.
 ## Additional resources
 
 - [Deployment plans video walkthrough](https://www.youtube.com/watch?v=YcIg5VCO98s)
-- [Debug contract](/stacks/clarinet/guides/debug-a-contract)
-- [Test contract](/stacks/clarinet/guides/testing-with-clarinet-sdk)
-- [Customize deployment](/stacks/clarinet/guides/create-deployment-plans)
+- [How to debug a contract](/stacks/clarinet/guides/debug-a-contract)
+- [How to test a contract](/stacks/clarinet-js-sdk/quickstart)
+- [How to customize deployment plans](/stacks/clarinet/guides/create-deployment-plans)

--- a/content/docs/stacks/platform/guides/deployment-plans.mdx
+++ b/content/docs/stacks/platform/guides/deployment-plans.mdx
@@ -67,9 +67,9 @@ If you want to create or update a new contract, refer to this [guide](/stacks/pl
 <Callout title="Note" type="info">
   If you add a new contract through Editor, ensure the new contract is
   configured to the `Clarinet.toml` file. For guidance, refer to [Clarinet.toml
-  configuration for new contracts](./build-contracts#add-a-new-contract). You
+  configuration for new contracts](/stacks/platform/guides/build-contracts#add-a-new-contract). You
   can also check your contracts before deploying them by following the [Check
-  contract]() guide.
+  contracts](/stacks/clarinet/guides/validate-a-contract) guide.
 </Callout>
 
 You can then use the **Regenerate plan** button to update your deployment plan with your new or updated contract.


### PR DESCRIPTION
Fixes a 404 error to the "test contract" link in the additional resources.

Updates language in additional resources for better Clarity

Fixes broken anchor link

Note: @ryanwaits  in a callout near the bottom there is a reference to a "Check contract" guide that just links to this same page. I'm not sure what that should point to, but I'm fine with simply removing that sentence altogether.
