### PR TITLE
Update build-contracts.mdx

### DIFF
--- a/content/docs/stacks/platform/guides/build-contracts.mdx
+++ b/content/docs/stacks/platform/guides/build-contracts.mdx
@@ -79,9 +79,9 @@ epoch = "2.4"
 
 You can customize, test, and debug your contracts using the VS Code terminal inside the Hiro Platform. On your projects page, select the "Open editor" button to open up the VS Code editor. Select the three horizontal lines icon to open a new terminal. Refer to the following documents to test your contracts in the VS Code terminal.
 
-- [Check contracts](/stacks/clarinet/guides/validate-a-contract)
-- [Test contracts](/stacks/clarinet/guides/testing-with-clarinet-sdk)
-- [Debug contracts](/stacks/clarinet/guides/debug-a-contract)
+- [Contract validation](/stacks/clarinet/guides/validate-a-contract)
+- [Unit testing](/stacks/clarinet-js-sdk/guides/unit-testing)
+- [Contract debugging](/stacks/clarinet/guides/debug-a-contract)
 
 <Callout title="Note">
   **`clarinet devnet start`** and **deployment plans** are currently not supported in


### PR DESCRIPTION
Fixes a 404 link and updates the phrasing for the linked guides for testing contracts
