### PR TITLE
add callouts for platform api

### DIFF
--- a/app/(docs)/[...slug]/page.tsx
+++ b/app/(docs)/[...slug]/page.tsx
@@ -48,6 +48,10 @@ export default function Page({ params }: { params: Param }): JSX.Element {
           ] || secondSegment.charAt(0).toUpperCase() + secondSegment.slice(1));
       }
 
+      if (page.slugs[1].toLowerCase() === "platform-api") {
+        prefix = "Platform API";
+      }
+
       if (page.slugs[1].toLowerCase() === "token-metadata-api") {
         prefix = "Token Metadata API";
       }

--- a/content/docs/stacks/platform/guides/create-chainhooks.mdx
+++ b/content/docs/stacks/platform/guides/create-chainhooks.mdx
@@ -5,6 +5,10 @@ description: Create a chainhook using the Hiro Platform.
 
 With Chainhook, you can automatically trigger an action in response to on-chain events on Stacks and Bitcoin, enabling you to use IFTTT (if_this, then_that) logic to power your applications. To learn more about Chainhook, refer to the [Chainhook overview](/stacks/chainhook).
 
+<Callout title="Programmatic API">
+  You can also create and manage chainhooks via the [Platform API](/stacks/platform-api/chainhooks).
+</Callout>
+
 To get started in the Hiro Platform, login and toggle to the Chainhook page. There are two ways to create a chainhook. You can either create a chainhook from scratch using the platform UI, or you can upload chainhooks that you have already defined in JSON.
 
 ![Create Chainhook Window](../images/chainhook/select-chainhook-tab.png)

--- a/content/docs/stacks/platform/guides/devnet.mdx
+++ b/content/docs/stacks/platform/guides/devnet.mdx
@@ -30,6 +30,10 @@ In the top right corner of your project page, you'll notice a devnet status indi
 
 ![Start Devnet](../images/devnet/start.png)
 
+<Callout title="Programmatic API">
+  You can also start and stop devnet programmatically via the [Platform API](/stacks/platform-api/devnet).
+</Callout>
+
 If you want to configure your devnet (like you can locally using `clarinet devnet start` in the terminal), open your project's `devnet.toml` file in the platform VS Code editor before you start devnet. From there, you can configure the settings to match your development needs.
 
 Once you start devnet, it will take a few moments to spin up. The status indicator on the project dashboard will keep you updated on the progress.


### PR DESCRIPTION
## What does this PR do?

Add a `Callout` inside the relative Platform guides letting developers know that they can create and manage Chainhooks and Devnet via the new Platform API.

Ref: https://github.com/hirosystems/docs/issues/745