### PR TITLE
hide cookbook url

### DIFF
--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -74,10 +74,10 @@ export const homeLayoutOptions: Omit<DocsLayoutProps, "children"> = {
       text: "Guides",
       url: "/guides",
     },
-    {
-      text: "Cookbook",
-      url: "/cookbook",
-    },
+    // {
+    //   text: "Cookbook",
+    //   url: "/cookbook",
+    // },
   ],
 };
 

--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -36,10 +36,10 @@ export const layoutOptions: Omit<DocsLayoutProps, "children"> = {
       text: "Guides",
       url: "/guides",
     },
-    {
-      text: "Cookbook",
-      url: "/cookbook",
-    },
+    // {
+    //   text: "Cookbook",
+    //   url: "/cookbook",
+    // },
   ],
   sidebar: {
     defaultOpenLevel: 0,


### PR DESCRIPTION
Fix: hide the Cookbook url in the top nav