### PR TITLE
fix: clarinet sbtc docs

### DIFF
--- a/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
+++ b/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
@@ -37,7 +37,7 @@ As a SIP-010 token, sBTC let you call the `transfer` function to transfer tokens
 Let's say we have an NFT contract that allows users to buy mint an NFT using sBTC.  
 
 
-```clarinet
+```clarity
 ;; this code is for demo purposes
 ;; it doesn't implement SIP-009 NFT standard
 (define-non-fungible-token nft-name uint)

--- a/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
+++ b/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
@@ -19,7 +19,7 @@ To use sBTC in your contract, you need to add the `sbtc-deposit` smart contract 
 
 In a Clarinet project, run the following command:
 
-```terminal
+```sh
 clarinet requirements add SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-deposit
 ```
 

--- a/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
+++ b/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
@@ -19,8 +19,8 @@ To use sBTC in your contract, you need to add the `sbtc-deposit` smart contract 
 
 In a Clarinet project, run the following command:
 
-```sh
-clarinet requirements add SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-deposit
+```terminal
+$ clarinet requirements add SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-deposit
 ```
 
 This will add the [`sbtc-deposit`](https://explorer.hiro.so/txid/SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-deposit)

--- a/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
+++ b/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
@@ -75,8 +75,7 @@ sure that your contracts call the right address.
 
 On testnet, the official Hiro sBTC contract is
 [ST1F7QA2MDF17S807EPA36TSS8AMEFY4KA9TVGWXT.sbtc-token](https://explorer.hiro.so/txid/ST1F7QA2MDF17S807EPA36TSS8AMEFY4KA9TVGWXT.sbtc-token?chain=testnet).
-This is is contract that is linked to the sBTC faucet (coming soon).
-{/* TODO: add link and instructions to use the faucet once ready */}
+This is the contract that is linked to the sBTC faucet (coming soon).
 
 Again, Clarinet will make sure that your contracts call this address when being deployed on mainnet.
 You can see the of the sbtc-contract being re-mapped in the testnet deployment plan.


### PR DESCRIPTION
## Description

Apparently `terminal` code blocks need to start with a `$`