### PR TITLE
fix: typo in clarinet sbtc doc

### DIFF
--- a/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
+++ b/content/docs/stacks/clarinet/guides/working-with-sbtc.mdx
@@ -34,7 +34,7 @@ sBTC that you can use to test your contract in the Simnet and Devnet.
 ## Using sBTC in your contract
 
 As a SIP-010 token, sBTC let you call the `transfer` function to transfer tokens from one address to another.  
-Let's say we have an NFT contract that allows users to buy mint an NFT using sBTC.  
+Let's say we have an NFT contract that allows users to mint an NFT by spending sBTC.  
 
 
 ```clarity


### PR DESCRIPTION
## Description

typo
