### PR TITLE
chore: remove part about clarity-lsp extension

### DIFF
--- a/content/docs/stacks/clarinet/clarity-formatter.mdx
+++ b/content/docs/stacks/clarinet/clarity-formatter.mdx
@@ -34,7 +34,6 @@ The [Clarity VS Code extension](https://marketplace.visualstudio.com/items?itemN
 -   **Format Selection**: Formats only the highlighted code (Right-click -> Format Selection).
 -   **Format On Save**: Automatically formats the file when you save it. This can be enabled in VS Code settings (`editor.formatOnSave`) and is off by default.
 
-You can find the settings by searching "clarity-lsp" from the settings menu (Ctrl+, / Cmd+,) or using the settings.json directly.
 For example, you can configure format-on-save for all clarity files within the settings.json with this entry:
 
 ```json -c


### PR DESCRIPTION
No need to mention the clarity-lsp extension since `editor.formatOnSave` is native VSCode