### PR TITLE
feat: add example token identifier

### DIFF
--- a/content/docs/stacks/api/tokens/holders.mdx
+++ b/content/docs/stacks/api/tokens/holders.mdx
@@ -34,7 +34,7 @@ Retrieves the list of fungible token holders for a given token ID. Specify `stx`
 
 <Property name={"token"} type={"string"} required={true} deprecated={false}>
 
-fungible token identifier
+fungible token identifier, e.g. `SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token`
 
 </Property>
 


### PR DESCRIPTION
## Description

Without this, it is unclear that the identifier should include the token name after a `::`. This originated from a user not understanding why their query wasn't working.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
