### PR TITLE
Correct invalid testnet address

### DIFF
--- a/content/docs/resources/clarity/(integrations)/external-data.mdx
+++ b/content/docs/resources/clarity/(integrations)/external-data.mdx
@@ -211,8 +211,8 @@ For testnet development, use these contract addresses:
 
 ```clarity
 ;; Testnet addresses
-(define-constant PYTH-ORACLE-CONTRACT-TESTNET 'ST3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v3)
-(define-constant PYTH-STORAGE-CONTRACT-TESTNET 'ST3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v3)
+(define-constant PYTH-ORACLE-CONTRACT-TESTNET 'ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-oracle-v3)
+(define-constant PYTH-STORAGE-CONTRACT-TESTNET 'ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-storage-v3)
 ```
 
 :::next-steps


### PR DESCRIPTION
The testnet addresses for PYTH-ORACLE-CONTRACT-TESTNET and PYTH-STORAGE-CONTRACT-TESTNET in the Hiro Clarity documentation were incorrect.

Previously listed address:

ST3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY

This address is not valid for testnet deployments.

✅ Updated to the correct testnet address:

ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH

This fix ensures developers using testnet get accurate contract references for pyth-oracle-v3 and pyth-storage-v3.