### PR TITLE
fix: clarinet installation instruction

### DIFF
--- a/content/docs/en/tools/clarinet/index.mdx
+++ b/content/docs/en/tools/clarinet/index.mdx
@@ -24,16 +24,19 @@ To explore Clarinet features with AI, copy and paste [llms.txt](/tools/clarinet/
 ## Installation
 
 <TerminalPicker storage="macOs">
-  ```terminal !! macOS
+  ```terminal !! Homebrew
   $ brew install clarinet
   ```
 
-  ```terminal !! Windows
+  ```terminal !! Winget
   $ winget install clarinet
   ```
 
-  ```terminal !! Cargo
+  ```terminal !! Source
   $ sudo apt install build-essential pkg-config libssl-dev
+  $ git clone https://github.com/hirosystems/clarinet
+  $ cd clarinet
+  $ cargo clarinet-install
   ```
 
   ```terminal !! Binary


### PR DESCRIPTION
Installation from source was missing the main steps. Thanks @aldur for noticing it.

Also updated the titles