### PR TITLE
chore: update pyth contracts to v4

### DIFF
--- a/content/docs/en/resources/clarity/(integrations)/external-data.mdx
+++ b/content/docs/en/resources/clarity/(integrations)/external-data.mdx
@@ -46,10 +46,10 @@ The Pyth integration on Stacks currently supports these price feeds:
 
     ```clarity
     ;; Pyth oracle contract addresses (mainnet)
-    (define-constant PYTH-ORACLE-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4)
-    (define-constant PYTH-STORAGE-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4)
-    (define-constant PYTH-DECODER-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-pnau-decoder-v3)
-    (define-constant WORMHOLE-CORE-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.wormhole-core-v3)
+    (define-constant PYTH-ORACLE-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4)
+    (define-constant PYTH-STORAGE-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4)
+    (define-constant PYTH-DECODER-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-pnau-decoder-v3)
+    (define-constant WORMHOLE-CORE-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.wormhole-core-v4)
 
     ;; Price feed IDs
     (define-constant BTC-USD-FEED-ID 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43)
@@ -203,16 +203,6 @@ Get multiple price feeds in one transaction:
   )
   (ok { btc: btc-price, eth: eth-price, stx: stx-price }))
 )
-```
-
-## Testnet deployment
-
-For testnet development, use these contract addresses:
-
-```clarity
-;; Testnet addresses
-(define-constant PYTH-ORACLE-CONTRACT-TESTNET 'ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-oracle-v4)
-(define-constant PYTH-STORAGE-CONTRACT-TESTNET 'ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-storage-v4)
 ```
 
 ## Next steps

--- a/content/docs/en/resources/guides/using-pyth-price-feeds.mdx
+++ b/content/docs/en/resources/guides/using-pyth-price-feeds.mdx
@@ -12,7 +12,7 @@ import { ArrowRight, Check } from 'lucide-react';
 This comprehensive guide walks you through integrating [Pyth Network](https://pyth.network)'s decentralized oracle for real-time price data in your Stacks applications. We'll build a complete example: an NFT that can only be minted by paying exactly $100 worth of sBTC.
 
 :::callout
-The Pyth protocol integration is available as a Beta on both testnet and mainnet networks. It's maintained by Trust Machines and provides access to real-time price feeds for BTC, STX, ETH, and USDC.
+The Pyth protocol integration is available on mainnet and maintained by Trust Machines, providing real-time price feeds for BTC, STX, ETH, and USDC.
 :::
 
 ## Architecture overview
@@ -84,10 +84,10 @@ We'll create a "Benjamin Club" - an exclusive NFT that costs exactly $100 worth 
     (define-constant ERR-STALE-PRICE (err u102))
 
     ;; Pyth oracle contracts
-    (define-constant PYTH-ORACLE 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4)
-    (define-constant PYTH-STORAGE 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4)
-    (define-constant PYTH-DECODER 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-pnau-decoder-v3)
-    (define-constant WORMHOLE-CORE 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.wormhole-core-v3)
+    (define-constant PYTH-ORACLE 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4)
+    (define-constant PYTH-STORAGE 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4)
+    (define-constant PYTH-DECODER 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-pnau-decoder-v3)
+    (define-constant WORMHOLE-CORE 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.wormhole-core-v4)
 
     ;; BTC price feed ID
     (define-constant BTC-USD-FEED-ID 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43)
@@ -391,9 +391,8 @@ Batch multiple price updates when possible:
 
 | Network | Contract | Address |
 |---------|----------|---------|
-| Mainnet | pyth-oracle-v4 | `SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4` |
-| Mainnet | pyth-storage-v4 | `SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4` |
-| Testnet | pyth-oracle-v4 | `ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-storage-v4` |
+| Mainnet | pyth-oracle-v4 | `SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4` |
+| Mainnet | pyth-storage-v4 | `SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4` |
 
 ### Price feed IDs
 

--- a/content/docs/en/tools/clarinet/(integrations)/pyth-oracle-integration.mdx
+++ b/content/docs/en/tools/clarinet/(integrations)/pyth-oracle-integration.mdx
@@ -34,16 +34,16 @@ description: Learn how to test smart contracts that depend on Pyth oracle price 
     name = "my-oracle-project"
     
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4"
-    
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4"
+
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4"
-    
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4"
+
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-pnau-decoder-v3"
-    
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-pnau-decoder-v3"
+
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.wormhole-core-v3"
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.wormhole-core-v4"
     ```
 
     This allows your tests to interact with the actual mainnet oracle contracts.
@@ -322,8 +322,8 @@ plan:
             contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R.benjamin-club
             method: initialize
             parameters:
-              - "'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4"
-              - "'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4"
+              - "'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4"
+              - "'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4"
 ```
 
 ### Gas estimation

--- a/content/docs/en/tools/clarinet/(overview)/faq.mdx
+++ b/content/docs/en/tools/clarinet/(overview)/faq.mdx
@@ -57,14 +57,14 @@ This page addresses common questions and issues encountered when developing with
         **Alternative: Manually use mainnet addresses:**
         ```typescript
         // Instead of using simnet.getAccounts()
-        const mainnetAddress = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY";
+        const mainnetAddress = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y";
 
         // Mint STX to any mainnet address
         simnet.mintSTX(mainnetAddress, 1000000n);
 
         // Call functions with mainnet address
         const result = simnet.callReadOnlyFn(
-          "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4",
+          "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4",
           "get-price",
           [priceFeed],
           mainnetAddress

--- a/content/docs/es/resources/clarity/(integrations)/external-data.mdx
+++ b/content/docs/es/resources/clarity/(integrations)/external-data.mdx
@@ -19,7 +19,7 @@ description: En esta guía, aprenderás cómo leer datos de precios en tiempo re
 
 Pyth Network utiliza una **basado en pull** modelo de oráculo, diferente de los oráculos tradicionales basados en push:
 
-* **Modelo push**: Oracle envía continuamente actualizaciones de precios en cadena
+* **Modelo push**: Oracle envía continuamente actualizaciones de precios en la cadena
 * **Modelo de extracción**: Los usuarios obtienen y envían actualizaciones de precios cuando es necesario
 
 Este enfoque es más eficiente en cuanto al gas y permite actualizaciones de precios con mayor frecuencia.
@@ -45,10 +45,10 @@ La integración de Pyth en Stacks actualmente admite estos feeds de precios:
 
     ```clarity
     ;; Pyth oracle contract addresses (mainnet)
-    (define-constant PYTH-ORACLE-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4)
-    (define-constant PYTH-STORAGE-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4)
-    (define-constant PYTH-DECODER-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-pnau-decoder-v3)
-    (define-constant WORMHOLE-CORE-CONTRACT 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.wormhole-core-v3)
+    (define-constant PYTH-ORACLE-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4)
+    (define-constant PYTH-STORAGE-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4)
+    (define-constant PYTH-DECODER-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-pnau-decoder-v3)
+    (define-constant WORMHOLE-CORE-CONTRACT 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.wormhole-core-v4)
 
     ;; Price feed IDs
     (define-constant BTC-USD-FEED-ID 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43)
@@ -202,16 +202,6 @@ Obtén múltiples fuentes de precios en una sola transacción:
   )
   (ok { btc: btc-price, eth: eth-price, stx: stx-price }))
 )
-```
-
-## Despliegue en testnet
-
-Para el desarrollo en testnet, utilice estas direcciones de contrato:
-
-```clarity
-;; Testnet addresses
-(define-constant PYTH-ORACLE-CONTRACT-TESTNET 'ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-oracle-v4)
-(define-constant PYTH-STORAGE-CONTRACT-TESTNET 'ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-storage-v4)
 ```
 
 ## Próximos pasos

--- a/content/docs/es/resources/guides/using-pyth-price-feeds.mdx
+++ b/content/docs/es/resources/guides/using-pyth-price-feeds.mdx
@@ -11,7 +11,7 @@ import { ArrowRight, Check } from 'lucide-react';
 Esta guía completa le guía a través de la integración [Red Pyth](https://pyth.network)'s oráculo descentralizado para datos de precios en tiempo real en sus aplicaciones de Stacks. Construiremos un ejemplo completo: un NFT que solo se puede acuñar pagando exactamente $100 en valor de sBTC.
 
 :::callout
-The Pyth protocol integration is available as a Beta on both testnet and mainnet networks. It's maintained by Trust Machines and provides access to real-time price feeds for BTC, STX, ETH, and USDC.
+The Pyth protocol integration is available on mainnet and maintained by Trust Machines, providing real-time price feeds for BTC, STX, ETH, and USDC.
 :::
 
 ## Descripción general de la arquitectura
@@ -78,7 +78,7 @@ Crearemos un "Benjamin Club" - un NFT exclusivo que cuesta exactamente $100 en v
   <Step>
     ### Escribir el contrato inteligente
 
-    Primero, implementa el contrato de Clarity que lee los datos de precios de Pyth:
+    Primero, implemente el contrato de Clarity que lee los datos de precios de Pyth:
 
     ```clarity contracts/benjamin-club.clar
     ;; Benjamin Club - $100 NFT minting contract
@@ -89,10 +89,10 @@ Crearemos un "Benjamin Club" - un NFT exclusivo que cuesta exactamente $100 en v
     (define-constant ERR-STALE-PRICE (err u102))
 
     ;; Pyth oracle contracts
-    (define-constant PYTH-ORACLE 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4)
-    (define-constant PYTH-STORAGE 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4)
-    (define-constant PYTH-DECODER 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-pnau-decoder-v3)
-    (define-constant WORMHOLE-CORE 'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.wormhole-core-v3)
+    (define-constant PYTH-ORACLE 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4)
+    (define-constant PYTH-STORAGE 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4)
+    (define-constant PYTH-DECODER 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-pnau-decoder-v3)
+    (define-constant WORMHOLE-CORE 'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.wormhole-core-v4)
 
     ;; BTC price feed ID
     (define-constant BTC-USD-FEED-ID 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43)
@@ -399,9 +399,8 @@ Agrupe múltiples actualizaciones de precios cuando sea posible:
 
 | Red | Contrato | Dirección |
 |---------|----------|---------|
-| Mainnet | pyth-oracle-v4 | `SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4` |
-| Mainnet | pyth-storage-v4 | `SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4` |
-| Red de prueba | pyth-oracle-v4 | `ST20M5GABDT6WYJHXBT5CDH4501V1Q65242SPRMXH.pyth-storage-v4` |
+| Mainnet | pyth-oracle-v4 | `SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4` |
+| Mainnet | pyth-storage-v4 | `SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4` |
 
 ### IDs de fuentes de precios
 

--- a/content/docs/es/tools/clarinet/(integrations)/pyth-oracle-integration.mdx
+++ b/content/docs/es/tools/clarinet/(integrations)/pyth-oracle-integration.mdx
@@ -32,16 +32,16 @@ description: Aprende cómo probar contratos inteligentes que dependen de los fee
     name = "my-oracle-project"
 
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4"
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4"
 
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4"
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4"
 
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-pnau-decoder-v3"
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-pnau-decoder-v3"
 
     [[project.requirements]]
-    contract_id = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.wormhole-core-v3"
+    contract_id = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.wormhole-core-v4"
     ```
 
     Esto permite que tus pruebas interactúen con los contratos de oráculo reales de la red principal.
@@ -172,7 +172,7 @@ description: Aprende cómo probar contratos inteligentes que dependen de los fee
   <Step>
     ### Configurar pruebas de ejecución en la red principal
 
-    Para pruebas de integración con datos reales del oráculo, utilice la ejecución de transacciones de mainnet:
+    Para pruebas de integración con datos reales del oráculo, utilice la ejecución de transacciones en mainnet:
 
     ```typescript tests/benjamin-club-mxs.test.ts
     import { buildDevnetNetworkOrchestrator } from "@hirosystems/clarinet-sdk";
@@ -269,7 +269,7 @@ export function setupPriceScenario(
 
 ### Probando la obsolescencia del precio
 
-Asegúrate de que tu contrato maneje correctamente los precios obsoletos:
+Asegúrese de que su contrato maneje correctamente los precios obsoletos:
 
 ```typescript tests/price-staleness.test.ts
 describe("Price Staleness Handling", () => {
@@ -320,13 +320,13 @@ plan:
             contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRCBGD7R.benjamin-club
             method: initialize
             parameters:
-              - "'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-oracle-v4"
-              - "'SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4"
+              - "'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-oracle-v4"
+              - "'SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4"
 ```
 
 ### Estimación de gas
 
-Probar el consumo de gas para operaciones de oráculo:
+Prueba el consumo de gas para operaciones de oráculo:
 
 ```typescript tests/gas-estimation.test.ts
 describe("Gas Estimation", () => {

--- a/content/docs/es/tools/clarinet/(overview)/faq.mdx
+++ b/content/docs/es/tools/clarinet/(overview)/faq.mdx
@@ -15,7 +15,7 @@ Esta página aborda preguntas y problemas comunes encontrados al desarrollar con
       <div className="pb-4 pt-2">
         Para probar con tokens sBTC, agregue el contrato sBTC de mainnet como requisito y acuñe tokens utilizando la dirección del implementador:
 
-        **Paso 1: Agregar sBTC como requisito**
+        **Paso 1: Agregar sBTC como un requisito**
 
         ```terminal
         $ clarinet requirements add SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token
@@ -61,14 +61,14 @@ Esta página aborda preguntas y problemas comunes encontrados al desarrollar con
 
         ```typescript
         // Instead of using simnet.getAccounts()
-        const mainnetAddress = "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY";
+        const mainnetAddress = "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y";
 
         // Mint STX to any mainnet address
         simnet.mintSTX(mainnetAddress, 1000000n);
 
         // Call functions with mainnet address
         const result = simnet.callReadOnlyFn(
-          "SP3R4F6C1J3JQWWCVZ3S7FRRYPMYG6ZW6RZK31FXY.pyth-storage-v4",
+          "SP1CGXWEAMG6P6FT04W66NVGJ7PQWMDAC19R7PJ0Y.pyth-storage-v4",
           "get-price",
           [priceFeed],
           mainnetAddress
@@ -136,7 +136,7 @@ Esta página aborda preguntas y problemas comunes encontrados al desarrollar con
 
 <Accordion type="single" collapsible>
   <AccordionItem value="mnemónica-24-palabras">
-    <AccordionTrigger>¿Por qué estoy obteniendo "bip39 error" al generar planes de implementación?</AccordionTrigger>
+    <AccordionTrigger>¿Por qué estoy recibiendo un "error bip39" al generar planes de implementación?</AccordionTrigger>
 
     <AccordionContent>
       <div className="pb-4 pt-2">
@@ -188,7 +188,7 @@ Esta página aborda preguntas y problemas comunes encontrados al desarrollar con
 
     <AccordionContent>
       <div className="pb-4 pt-2">
-        La transición de la época 3.0 en devnet puede ser inestable, con tasas de éxito que varían entre el 50-80% dependiendo de tu configuración.
+        La transición de la época 3.0 en devnet puede ser inestable, con tasas de éxito que varían entre el 50-80% dependiendo de su configuración.
 
         **Soluciones temporales actuales:**
 

--- a/idioma.lock
+++ b/idioma.lock
@@ -265,7 +265,7 @@ files:
     translations:
       es: true
   content/docs/en/tools/clarinet/(overview)/faq.mdx:
-    content: 926ae4192884e56f8721193653aa7813
+    content: 763821eb286e465861569c21987ec306
     translations:
       es: true
   content/docs/en/tools/clarinet/(integrations)/stacks-js-integration.mdx:
@@ -273,7 +273,7 @@ files:
     translations:
       es: true
   content/docs/en/tools/clarinet/(integrations)/pyth-oracle-integration.mdx:
-    content: 2ae7f0d8bc9074759734cd3c77f16b1b
+    content: 54994516766408e87a28e4f5479754f6
     translations:
       es: true
   content/docs/en/tools/clarinet/(integrations)/chainhook-integration.mdx:
@@ -1141,7 +1141,7 @@ files:
     translations:
       es: true
   content/docs/en/resources/guides/using-pyth-price-feeds.mdx:
-    content: 0a7fb4d664da8de1f8514b915483fa6e
+    content: 614391eb41539fcd01db2c1e3d900d45
     translations:
       es: true
   content/docs/en/tools/clarinet/(overview)/quickstart.mdx:
@@ -1189,7 +1189,7 @@ files:
     translations:
       es: true
   content/docs/en/resources/clarity/(integrations)/external-data.mdx:
-    content: fd8afa4a53e0a109030dbf09491f2602
+    content: 585215d8f46e5fb52a3c768344381fcf
     translations:
       es: true
   content/docs/en/apis/stacks-node-rpc-api/usage.mdx:


### PR DESCRIPTION
Updated Pyth oracle contract references to v4 and migrated all relevant contract integrations to use the latest version.