### PR TITLE
Add notification for PG_SCHEMA

### DIFF
--- a/content/docs/en/resources/archive/stacks-api.mdx
+++ b/content/docs/en/resources/archive/stacks-api.mdx
@@ -21,6 +21,12 @@ There are two ways to restore a Stacks Blockchain API using the Hiro Archive. Th
 
 This is the quickest and most direct method, and it is suitable for most scenarios. It consists of a backup of the API's Postgres database taken using `pg_dump`. We generally recommend starting with this method before attempting the method below if this one does not work for any reason.
 
+:::callout
+type: info
+### Postgres Schema
+You will need to set the API `PG_SCHEMA` environment variable to: `PG_SCHEMA=stacks_blockchain_api` when restoring from an archive.
+:::
+
 **Restore via tab-separated-values (TSV) file**
 
 This method is several times slower than restoring from a Postgres dump. The API TSV file contains the raw unprocessed events from a Stacks blockchain node. The API can ingest this file to process events into a Postgres database.


### PR DESCRIPTION
Adds a flag to `./en/resources/archive/stacks-api` to specifically mention adding/updating the api's `PG_SCHEMA` env var to use the one used in the pg_dump. 

untested, but used similar wording/format to the download guide for macos users: https://docs.hiro.so/en/resources/archive/download-guide